### PR TITLE
ci: use GitHub App token for release-please and fix docs

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -13,9 +13,17 @@ jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate app token
+        id: app-token
+        uses: actions/create-github-app-token@v2
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         id: release
         with:
+          token: ${{ steps.app-token.outputs.token }}
           release-type: php
           package-name: zappzarapp/security
 
@@ -43,9 +51,6 @@ jobs:
 
       - name: Upload SBOM to release
         if: ${{ steps.release.outputs.release_created }}
-        uses: softprops/action-gh-release@v2
-        with:
-          files: sbom.json
-          tag_name: ${{ steps.release.outputs.tag_name }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+        run: gh release upload ${{ steps.release.outputs.tag_name }} sbom.json --clobber

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -62,7 +62,7 @@ All contributions must pass:
 - PHP-CS-Fixer style
 - Deptrac architecture boundaries
 - High test coverage for new code (>95%, excluding untestable I/O code)
-- **High mutation score** (Infection, >95%)
+- **100% mutation score** (Infection, enforced in CI)
 
 ## Architecture Rules (Deptrac)
 


### PR DESCRIPTION
## Summary
- Use `marcstraube-release-bot` app token for release-please (fixes CI not triggering on release PRs)
- Replace `softprops/action-gh-release` with `gh release upload` for SBOM (consistent with php-audit-logger)
- Fix CONTRIBUTING.md mutation score documentation: >95% → 100% (matches actual CI enforcement)

## Test plan
- [x] All local quality checks pass
- [ ] CI passes on this PR
- [ ] After merge: release-please PRs trigger CI workflows

🤖 Generated with [Claude Code](https://claude.com/claude-code)