### PR TITLE
style: fix match expression alignment for php-cs-fixer 3.95

### DIFF
--- a/src/Csp/SecurityPolicy.php
+++ b/src/Csp/SecurityPolicy.php
@@ -54,7 +54,7 @@ enum SecurityPolicy
     {
         return match ($this) {
             self::LENIENT, self::UNSAFE_EVAL => true,
-            default => false,
+            default                          => false,
         };
     }
 
@@ -65,7 +65,7 @@ enum SecurityPolicy
     {
         return match ($this) {
             self::LENIENT, self::UNSAFE_INLINE => true,
-            default => false,
+            default                            => false,
         };
     }
 }

--- a/src/Sanitization/Html/HtmlSanitizer.php
+++ b/src/Sanitization/Html/HtmlSanitizer.php
@@ -227,19 +227,19 @@ final readonly class HtmlSanitizer implements InputFilter
     private function isUrlAttribute(string $element, string $attribute): bool
     {
         return match ($element) {
-            'a', 'area'              => $attribute === 'href',
-            'img'                    => $attribute === 'src' || $attribute === 'srcset',
-            'form'                   => $attribute === 'action',
-            'video'                  => $attribute === 'src' || $attribute === 'poster',
-            'audio', 'source'        => $attribute === 'src',
-            'track'                  => $attribute === 'src',
-            'iframe', 'embed'        => $attribute === 'src',
-            'object'                 => $attribute === 'data',
-            'input'                  => $attribute === 'src' || $attribute === 'formaction',
-            'button'                 => $attribute === 'formaction',
-            'link'                   => $attribute === 'href',
+            'a', 'area'                     => $attribute === 'href',
+            'img'                           => $attribute === 'src' || $attribute === 'srcset',
+            'form'                          => $attribute === 'action',
+            'video'                         => $attribute === 'src' || $attribute === 'poster',
+            'audio', 'source'               => $attribute === 'src',
+            'track'                         => $attribute === 'src',
+            'iframe', 'embed'               => $attribute === 'src',
+            'object'                        => $attribute === 'data',
+            'input'                         => $attribute === 'src' || $attribute === 'formaction',
+            'button'                        => $attribute === 'formaction',
+            'link'                          => $attribute === 'href',
             'blockquote', 'q', 'del', 'ins' => $attribute === 'cite',
-            default                  => false,
+            default                         => false,
         };
     }
 

--- a/src/Sanitization/Uri/UriScheme.php
+++ b/src/Sanitization/Uri/UriScheme.php
@@ -28,7 +28,7 @@ enum UriScheme: string
     {
         return match ($this) {
             self::JAVASCRIPT, self::VBSCRIPT, self::DATA => true,
-            default => false,
+            default                                      => false,
         };
     }
 
@@ -39,7 +39,7 @@ enum UriScheme: string
     {
         return match ($this) {
             self::HTTP, self::HTTPS, self::MAILTO, self::TEL => true,
-            default => false,
+            default                                          => false,
         };
     }
 }

--- a/src/Sri/HashAlgorithm.php
+++ b/src/Sri/HashAlgorithm.php
@@ -63,7 +63,7 @@ enum HashAlgorithm: string
         return match (strtolower($algorithm)) {
             'sha384', 'sha-384' => self::SHA384,
             'sha512', 'sha-512' => self::SHA512,
-            default => null,
+            default             => null,
         };
     }
 }


### PR DESCRIPTION
## Summary
- Fix match expression alignment in 4 files for compatibility with php-cs-fixer 3.95
- Whitespace-only changes, no logic affected

## Context
Dependabot PR #18 brings php-cs-fixer 3.95 which enforces stricter match expression alignment. Pre-fixing on master so the Dependabot PR passes CI after rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)