### PR TITLE
ci: add CI gate, dependabot auto-merge, and security labeling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,44 @@ permissions:
   contents: read
 
 jobs:
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      source: ${{ steps.filter.outputs.source }}
+      deps: ${{ steps.filter.outputs.deps }}
+      release-please: ${{ steps.release.outputs.match }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Detect changed paths
+        uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            source:
+              - 'src/**'
+              - 'tests/**'
+            deps:
+              - 'composer.json'
+              - 'composer.lock'
+
+      - name: Check for release-please branch
+        id: release
+        run: |
+          if [[ "${{ github.head_ref }}" == release-please--* ]]; then
+            echo "match=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "match=false" >> "$GITHUB_OUTPUT"
+          fi
+
   security-analysis:
     name: Security Analysis (Psalm Taint)
+    needs: changes
+    if: >-
+      needs.changes.outputs.release-please != 'true' &&
+      (needs.changes.outputs.source == 'true' ||
+       needs.changes.outputs.deps == 'true')
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -42,6 +78,11 @@ jobs:
 
   tests:
     name: PHP ${{ matrix.php }} Tests
+    needs: changes
+    if: >-
+      needs.changes.outputs.release-please != 'true' &&
+      (needs.changes.outputs.source == 'true' ||
+       needs.changes.outputs.deps == 'true')
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -114,3 +155,26 @@ jobs:
         with:
           files: ./coverage.xml
           fail_ci_if_error: false
+
+  # =============================================================================
+  # CI GATE (single required check for branch protection)
+  # =============================================================================
+  ci-gate:
+    name: CI Gate
+    runs-on: ubuntu-latest
+    if: always()
+    needs: [changes, security-analysis, tests]
+    steps:
+      - name: Check required job results
+        run: |
+          results=(
+            "${{ needs.security-analysis.result }}"
+            "${{ needs.tests.result }}"
+          )
+          for r in "${results[@]}"; do
+            if [ "$r" = "failure" ] || [ "$r" = "cancelled" ]; then
+              echo "::error::Required job failed or was cancelled: $r"
+              exit 1
+            fi
+          done
+          echo "All required jobs passed."

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,36 @@
+name: Dependabot Auto-Merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve minor and patch updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr review --approve "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Enable auto-merge for minor and patch updates
+        if: >-
+          steps.metadata.outputs.update-type == 'version-update:semver-minor'
+          || steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/dependabot-security-label.yml
+++ b/.github/workflows/dependabot-security-label.yml
@@ -1,0 +1,27 @@
+name: Dependabot Security Label
+
+on:
+  pull_request:
+    types: [opened]
+
+permissions:
+  pull-requests: write
+
+jobs:
+  label:
+    if: github.actor == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Add security label
+        if: steps.metadata.outputs.ghsa-id != ''
+        run: gh pr edit "$PR_URL" --add-label "security"
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Add **CI Gate** job as single required check for branch protection (replaces listing individual jobs)
- Add **path filtering** and **release-please detection** to skip CI on release PRs and non-code changes
- Add **Dependabot auto-merge** workflow for minor/patch updates on green CI
- Add **Dependabot security label** workflow to tag PRs with `security` when a GHSA is referenced

## Setup required
- Update branch protection on `master`: set "CI Gate" as the only required status check
- Ensure "Allow auto-merge" is enabled in repository settings

## Test plan
- [ ] Verify CI Gate passes on this PR
- [ ] After merge: verify auto-merge triggers on next Dependabot minor/patch PR
- [ ] After merge: verify release-please PRs skip heavy CI jobs

🤖 Generated with [Claude Code](https://claude.com/claude-code)