### PR TITLE
feat(headers): add security header analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Limiting, SRI, and Audit Logging.
 | **Sanitization** | Input sanitization (HTML, SQL, URI, Path)         | `HtmlSanitizer`, `UriSanitizer`, `PathValidator`                   |
 | **RateLimiting** | Rate limiting with multiple algorithms            | `DefaultRateLimiter`, `RateLimitConfig`                            |
 | **SRI**          | Subresource Integrity hash generation             | `SriHashGenerator`, `IntegrityAttribute`                           |
+| **Analyzer**     | Security header analysis and auditing             | `SecurityHeaderAnalyzer`, `AnalysisResult`                         |
 | **Logging**      | Security event audit logging                      | `SecurityAuditLogger`, `SecurityEvent`                             |
 
 ## Requirements
@@ -126,6 +127,7 @@ options, and code examples:
 | [Sanitization](docs/sanitization.md)      | HTML, URI, path sanitization        |
 | [Rate Limiting](docs/rate-limiting.md)    | Token bucket, sliding window        |
 | [SRI](docs/sri.md)                        | Subresource integrity hashes        |
+| [Analyzer](docs/analyzer.md)             | Security header auditing            |
 | [Logging](docs/logging.md)               | Security audit logging              |
 | [Glossary](docs/glossary.md)             | Security terminology reference      |
 

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -79,6 +79,11 @@ deptrac:
         - type: directory
           value: src/Headers/PermissionsPolicy/
 
+    - name: HeadersAnalyzer
+      collectors:
+        - type: directory
+          value: src/Headers/Analyzer/
+
     - name: HeadersBuilder
       collectors:
         - type: directory
@@ -326,6 +331,7 @@ deptrac:
     HeadersPermissionsPolicy:
       - HeadersException
       - HeadersValidation
+    HeadersAnalyzer: ~
     HeadersBuilder:
       - HeadersMain
       - HeadersEnums

--- a/docs/analyzer.md
+++ b/docs/analyzer.md
@@ -1,0 +1,132 @@
+# Security Header Analyzer
+
+Inspect HTTP response headers for missing, weak, or misconfigured security
+headers. Returns structured findings with severity levels and actionable
+recommendations.
+
+## Quick Start
+
+```php
+use Zappzarapp\Security\Headers\Analyzer\SecurityHeaderAnalyzer;
+
+$analyzer = new SecurityHeaderAnalyzer();
+
+$result = $analyzer->analyze([
+    'Strict-Transport-Security' => 'max-age=3600',
+    'X-Content-Type-Options' => 'nosniff',
+]);
+
+foreach ($result->findings() as $finding) {
+    printf(
+        "[%s] %s: %s\n  -> %s\n",
+        strtoupper($finding->severity->value),
+        $finding->header,
+        $finding->message,
+        $finding->recommendation,
+    );
+}
+```
+
+## Classes
+
+| Class                      | Description                                    |
+| -------------------------- | ---------------------------------------------- |
+| `SecurityHeaderAnalyzer`   | Analyzes headers and returns findings          |
+| `AnalysisResult`           | Immutable collection of findings               |
+| `Finding`                  | Single issue with header, severity, and advice |
+| `FindingSeverity`          | Enum: CRITICAL, HIGH, MEDIUM, LOW, INFO        |
+
+## Severity Levels
+
+| Level    | Meaning                                                   |
+| -------- | --------------------------------------------------------- |
+| CRITICAL | Immediate security risk                                   |
+| HIGH     | Missing essential header or dangerous misconfiguration     |
+| MEDIUM   | Suboptimal configuration that weakens security             |
+| LOW      | Missing recommended header with limited impact             |
+| INFO     | Optional header not present, informational only            |
+
+## Checks
+
+### Strict-Transport-Security (HSTS)
+
+- Missing header (HIGH)
+- max-age below 1 year (MEDIUM)
+- Missing includeSubDomains (MEDIUM)
+
+### Content-Security-Policy (CSP)
+
+- Missing header (HIGH)
+- `unsafe-inline` in script-src (HIGH)
+- `unsafe-eval` in script-src (HIGH)
+- `unsafe-inline` in style-src (MEDIUM)
+- Wildcard `*` source in any directive (HIGH)
+- Missing default-src (MEDIUM)
+
+### X-Frame-Options
+
+- Missing header (MEDIUM)
+
+### X-Content-Type-Options
+
+- Missing header (MEDIUM)
+- Value other than `nosniff` (MEDIUM)
+
+### Referrer-Policy
+
+- Missing header (LOW)
+- `unsafe-url` policy (HIGH)
+- `no-referrer-when-downgrade` policy (LOW)
+
+### Permissions-Policy
+
+- Missing header (LOW)
+
+### Cross-Origin Headers (COOP, COEP, CORP)
+
+- Missing COOP (LOW)
+- Missing COEP (INFO)
+- Missing CORP (INFO)
+
+## Working with Results
+
+```php
+$result = $analyzer->analyze($headers);
+
+// Check severity thresholds
+if ($result->hasHighOrAbove()) {
+    // Fail CI pipeline or raise alert
+}
+
+// Filter by header
+$hstsIssues = $result->forHeader('Strict-Transport-Security');
+
+// Check if everything is secure
+if ($result->isClean()) {
+    // All headers properly configured
+}
+
+// Count total findings
+echo $result->count() . ' issues found';
+```
+
+## CI Integration
+
+Use the analyzer in CI pipelines to enforce security header policies:
+
+```php
+$result = $analyzer->analyze($headers);
+
+if ($result->hasHighOrAbove()) {
+    foreach ($result->findings() as $finding) {
+        fwrite(STDERR, sprintf(
+            "[%s] %s: %s\n",
+            $finding->severity->value,
+            $finding->header,
+            $finding->message,
+        ));
+    }
+
+    exit(1);
+}
+```

--- a/docs/index.md
+++ b/docs/index.md
@@ -15,6 +15,7 @@ vulnerabilities.
 | [Sanitization](sanitization.md)   | HTML, URI, and path sanitization to prevent XSS and injection attacks                      |
 | [Rate Limiting](rate-limiting.md) | Token bucket and sliding window rate limiting with storage backends                        |
 | [SRI](sri.md)                     | Subresource Integrity hash generation and verification with SSRF protection                |
+| [Analyzer](analyzer.md)           | Security header analyzer for auditing and CI integration                                   |
 | [Logging](logging.md)             | Security audit logging with correlation IDs                                                |
 | [Glossary](glossary.md)           | Security terms and concepts explained                                                      |
 

--- a/infection.json5
+++ b/infection.json5
@@ -27,7 +27,9 @@
                 // EQUIVALENT on 64-bit PHP: sprintf('%u', $long) returns string,
                 // but PHP type juggling converts it to int for comparison with
                 // integer constants. Both signed and unsigned values fit in 64-bit int.
-                "Zappzarapp\\Security\\Sanitization\\Uri\\PrivateNetworkValidator::isPrivateIpv4"
+                "Zappzarapp\\Security\\Sanitization\\Uri\\PrivateNetworkValidator::isPrivateIpv4",
+                // EQUIVALENT: preg_match captures string, PHP type-juggles to int for < comparison
+                "Zappzarapp\\Security\\Headers\\Analyzer\\SecurityHeaderAnalyzer::analyzeHsts"
             ]
         },
         "Division": {
@@ -43,7 +45,9 @@
         },
         "Plus": {
             "ignore": [
-                "Zappzarapp\\Security\\RateLimiting\\Algorithm\\*"
+                "Zappzarapp\\Security\\RateLimiting\\Algorithm\\*",
+                // CSP parser offset — equivalent when directive name doesn't match patterns
+                "Zappzarapp\\Security\\Headers\\Analyzer\\SecurityHeaderAnalyzer::parseCspDirectives"
             ]
         },
         "OneZeroFloat": {
@@ -57,7 +61,15 @@
                 // Returning only first DNS record vs all records - gethostbyname
                 // usually provides the primary IP, dns_get_record is for additional IPs.
                 // Requires real network with multi-record responses to kill.
-                "Zappzarapp\\Security\\Sanitization\\Uri\\NativeDnsResolver::resolveViaDnsGetRecord"
+                "Zappzarapp\\Security\\Sanitization\\Uri\\NativeDnsResolver::resolveViaDnsGetRecord",
+                // Early returns where findings array always has exactly 1 element
+                "Zappzarapp\\Security\\Headers\\Analyzer\\SecurityHeaderAnalyzer::*"
+            ]
+        },
+        "UnwrapArrayValues": {
+            "ignore": [
+                // Variadic ...$findings already produces a list, array_values is defensive
+                "Zappzarapp\\Security\\Headers\\Analyzer\\AnalysisResult::*"
             ]
         },
 
@@ -193,7 +205,9 @@
                 // Due to long2ip() using only lower 32 bits, the embedded IPv4
                 // (at positions 24-31) is preserved even when using full hex.
                 // hexdec overflow wraps to the same lower 32 bits.
-                "Zappzarapp\\Security\\Sanitization\\Uri\\PrivateNetworkValidator::isPrivateIpv6"
+                "Zappzarapp\\Security\\Sanitization\\Uri\\PrivateNetworkValidator::isPrivateIpv6",
+                // CSP parser: directive name included in sources doesn't affect pattern matching
+                "Zappzarapp\\Security\\Headers\\Analyzer\\SecurityHeaderAnalyzer::parseCspDirectives"
             ]
         },
 
@@ -244,7 +258,9 @@
                 // HTTP client defaults - operational configuration
                 "Zappzarapp\\Security\\Sri\\FileGetContentsHttpClient::*",
                 // Rate-limiting algorithms
-                "Zappzarapp\\Security\\RateLimiting\\Algorithm\\*"
+                "Zappzarapp\\Security\\RateLimiting\\Algorithm\\*",
+                // CSP parser offset — equivalent when directive name doesn't match patterns
+                "Zappzarapp\\Security\\Headers\\Analyzer\\SecurityHeaderAnalyzer::parseCspDirectives"
             ]
         },
         "LessThan": {

--- a/src/Headers/Analyzer/AnalysisResult.php
+++ b/src/Headers/Analyzer/AnalysisResult.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Headers\Analyzer;
+
+use Countable;
+
+/**
+ * Immutable collection of security header analysis findings
+ */
+final readonly class AnalysisResult implements Countable
+{
+    /** @var list<Finding> */
+    private array $findings;
+
+    public function __construct(Finding ...$findings)
+    {
+        $this->findings = array_values($findings);
+    }
+
+    /**
+     * @return list<Finding>
+     */
+    public function findings(): array
+    {
+        return $this->findings;
+    }
+
+    /**
+     * Get findings for a specific header
+     *
+     * @return list<Finding>
+     */
+    public function forHeader(string $header): array
+    {
+        return array_values(
+            array_filter(
+                $this->findings,
+                static fn (Finding $finding): bool => strcasecmp($finding->header, $header) === 0,
+            ),
+        );
+    }
+
+    /**
+     * Check if there are any findings with CRITICAL severity
+     */
+    public function hasCritical(): bool
+    {
+        return $this->hasSeverity(FindingSeverity::CRITICAL);
+    }
+
+    /**
+     * Check if there are any findings with HIGH or CRITICAL severity
+     */
+    public function hasHighOrAbove(): bool
+    {
+        if ($this->hasCritical()) {
+            return true;
+        }
+
+        return $this->hasSeverity(FindingSeverity::HIGH);
+    }
+
+    /**
+     * Check if there are no findings at all
+     */
+    public function isClean(): bool
+    {
+        return $this->findings === [];
+    }
+
+    public function count(): int
+    {
+        return count($this->findings);
+    }
+
+    private function hasSeverity(FindingSeverity $severity): bool
+    {
+        return array_any($this->findings, static fn (Finding $finding): bool => $finding->severity === $severity);
+    }
+}

--- a/src/Headers/Analyzer/Finding.php
+++ b/src/Headers/Analyzer/Finding.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Headers\Analyzer;
+
+/**
+ * A single security header finding
+ */
+final readonly class Finding
+{
+    public function __construct(
+        public string $header,
+        public FindingSeverity $severity,
+        public string $message,
+        public string $recommendation,
+    ) {
+    }
+}

--- a/src/Headers/Analyzer/FindingSeverity.php
+++ b/src/Headers/Analyzer/FindingSeverity.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Headers\Analyzer;
+
+/**
+ * Severity level for security header findings
+ */
+enum FindingSeverity: string
+{
+    case CRITICAL = 'critical';
+    case HIGH     = 'high';
+    case MEDIUM   = 'medium';
+    case LOW      = 'low';
+    case INFO     = 'info';
+}

--- a/src/Headers/Analyzer/SecurityHeaderAnalyzer.php
+++ b/src/Headers/Analyzer/SecurityHeaderAnalyzer.php
@@ -1,0 +1,376 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Headers\Analyzer;
+
+/**
+ * Analyzes HTTP response headers for security issues
+ *
+ * Inspects headers for missing, weak, or misconfigured security headers
+ * and returns structured findings with actionable recommendations.
+ */
+final class SecurityHeaderAnalyzer
+{
+    private const int HSTS_MIN_MAX_AGE = 31_536_000;
+
+    /**
+     * Analyze response headers for security issues
+     *
+     * @param array<string, string> $headers Header name => value map (case-insensitive matching)
+     */
+    public function analyze(array $headers): AnalysisResult
+    {
+        $normalized = $this->normalizeHeaders($headers);
+
+        $findings = [
+            ...$this->analyzeHsts($normalized),
+            ...$this->analyzeCsp($normalized),
+            ...$this->analyzeXFrameOptions($normalized),
+            ...$this->analyzeXContentTypeOptions($normalized),
+            ...$this->analyzeReferrerPolicy($normalized),
+            ...$this->analyzePermissionsPolicy($normalized),
+            ...$this->analyzeCoop($normalized),
+            ...$this->analyzeCoep($normalized),
+            ...$this->analyzeCorp($normalized),
+        ];
+
+        return new AnalysisResult(...$findings);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeHsts(array $headers): array
+    {
+        $findings = [];
+        $value    = $headers['strict-transport-security'] ?? null;
+
+        if ($value === null) {
+            $findings[] = new Finding(
+                'Strict-Transport-Security',
+                FindingSeverity::HIGH,
+                'HSTS header is missing',
+                'Add Strict-Transport-Security header with max-age of at least 1 year and includeSubDomains',
+            );
+
+            return $findings;
+        }
+
+        if (preg_match('/max-age=(\d+)/i', $value, $matches)) {
+            $maxAge = (int) $matches[1];
+
+            if ($maxAge < self::HSTS_MIN_MAX_AGE) {
+                $findings[] = new Finding(
+                    'Strict-Transport-Security',
+                    FindingSeverity::MEDIUM,
+                    sprintf('HSTS max-age is %d seconds, recommended minimum is %d (1 year)', $maxAge, self::HSTS_MIN_MAX_AGE),
+                    'Increase max-age to at least 31536000 (1 year), ideally 63072000 (2 years)',
+                );
+            }
+        }
+
+        if (!str_contains(strtolower($value), 'includesubdomains')) {
+            $findings[] = new Finding(
+                'Strict-Transport-Security',
+                FindingSeverity::MEDIUM,
+                'HSTS header is missing includeSubDomains directive',
+                'Add includeSubDomains to protect all subdomains',
+            );
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeCsp(array $headers): array
+    {
+        $findings = [];
+        $value    = $headers['content-security-policy'] ?? null;
+
+        if ($value === null) {
+            $findings[] = new Finding(
+                'Content-Security-Policy',
+                FindingSeverity::HIGH,
+                'CSP header is missing',
+                'Add a Content-Security-Policy header to prevent XSS and data injection attacks',
+            );
+
+            return $findings;
+        }
+
+        $directives = $this->parseCspDirectives($value);
+
+        if (!isset($directives['default-src'])) {
+            $findings[] = new Finding(
+                'Content-Security-Policy',
+                FindingSeverity::MEDIUM,
+                'CSP is missing default-src directive',
+                'Add default-src as a fallback for other fetch directives',
+            );
+        }
+
+        $scriptSrc = $directives['script-src'] ?? $directives['default-src'] ?? '';
+
+        if (str_contains($scriptSrc, "'unsafe-inline'")) {
+            $findings[] = new Finding(
+                'Content-Security-Policy',
+                FindingSeverity::HIGH,
+                "CSP allows 'unsafe-inline' in script-src, enabling inline script execution",
+                "Remove 'unsafe-inline' from script-src and use nonce-based or hash-based CSP instead",
+            );
+        }
+
+        if (str_contains($scriptSrc, "'unsafe-eval'")) {
+            $findings[] = new Finding(
+                'Content-Security-Policy',
+                FindingSeverity::HIGH,
+                "CSP allows 'unsafe-eval' in script-src, enabling eval() and similar functions",
+                "Remove 'unsafe-eval' from script-src and refactor code to avoid eval()",
+            );
+        }
+
+        $styleSrc = $directives['style-src'] ?? $directives['default-src'] ?? '';
+
+        if (str_contains($styleSrc, "'unsafe-inline'")) {
+            $findings[] = new Finding(
+                'Content-Security-Policy',
+                FindingSeverity::MEDIUM,
+                "CSP allows 'unsafe-inline' in style-src",
+                "Consider removing 'unsafe-inline' from style-src and use nonce-based or hash-based CSP for styles",
+            );
+        }
+
+        foreach ($directives as $directive => $sources) {
+            if (preg_match('/(?:^|\s)\*(?:\s|$)/', $sources) && $directive !== 'report-uri') {
+                $findings[] = new Finding(
+                    'Content-Security-Policy',
+                    FindingSeverity::HIGH,
+                    sprintf("CSP directive '%s' uses wildcard (*) source, allowing any origin", $directive),
+                    sprintf("Replace wildcard in '%s' with specific trusted origins", $directive),
+                );
+            }
+        }
+
+        return $findings;
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeXFrameOptions(array $headers): array
+    {
+        if (!isset($headers['x-frame-options'])) {
+            return [new Finding(
+                'X-Frame-Options',
+                FindingSeverity::MEDIUM,
+                'X-Frame-Options header is missing',
+                'Add X-Frame-Options: DENY or SAMEORIGIN to prevent clickjacking, or use CSP frame-ancestors',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeXContentTypeOptions(array $headers): array
+    {
+        $value = $headers['x-content-type-options'] ?? null;
+
+        if ($value === null) {
+            return [new Finding(
+                'X-Content-Type-Options',
+                FindingSeverity::MEDIUM,
+                'X-Content-Type-Options header is missing',
+                'Add X-Content-Type-Options: nosniff to prevent MIME-type sniffing',
+            )];
+        }
+
+        if (strtolower(trim($value)) !== 'nosniff') {
+            return [new Finding(
+                'X-Content-Type-Options',
+                FindingSeverity::MEDIUM,
+                sprintf('X-Content-Type-Options has invalid value "%s"', $value),
+                'Set X-Content-Type-Options to "nosniff" (the only valid value)',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeReferrerPolicy(array $headers): array
+    {
+        $value = $headers['referrer-policy'] ?? null;
+
+        if ($value === null) {
+            return [new Finding(
+                'Referrer-Policy',
+                FindingSeverity::LOW,
+                'Referrer-Policy header is missing',
+                'Add Referrer-Policy: strict-origin-when-cross-origin for a good balance of security and functionality',
+            )];
+        }
+
+        $policy = strtolower(trim($value));
+
+        if ($policy === 'unsafe-url') {
+            return [new Finding(
+                'Referrer-Policy',
+                FindingSeverity::HIGH,
+                'Referrer-Policy is set to "unsafe-url", leaking full URLs to all origins',
+                'Change Referrer-Policy to "strict-origin-when-cross-origin" or "no-referrer"',
+            )];
+        }
+
+        if ($policy === 'no-referrer-when-downgrade') {
+            return [new Finding(
+                'Referrer-Policy',
+                FindingSeverity::LOW,
+                'Referrer-Policy "no-referrer-when-downgrade" leaks full URL on same-protocol navigations',
+                'Consider using "strict-origin-when-cross-origin" for better privacy',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzePermissionsPolicy(array $headers): array
+    {
+        if (!isset($headers['permissions-policy'])) {
+            return [new Finding(
+                'Permissions-Policy',
+                FindingSeverity::LOW,
+                'Permissions-Policy header is missing',
+                'Add Permissions-Policy to restrict browser feature access (camera, microphone, geolocation, etc.)',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeCoop(array $headers): array
+    {
+        if (!isset($headers['cross-origin-opener-policy'])) {
+            return [new Finding(
+                'Cross-Origin-Opener-Policy',
+                FindingSeverity::LOW,
+                'COOP header is missing',
+                'Add Cross-Origin-Opener-Policy: same-origin to isolate your browsing context',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeCoep(array $headers): array
+    {
+        if (!isset($headers['cross-origin-embedder-policy'])) {
+            return [new Finding(
+                'Cross-Origin-Embedder-Policy',
+                FindingSeverity::INFO,
+                'COEP header is missing',
+                'Add Cross-Origin-Embedder-Policy: require-corp if cross-origin isolation is needed',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * @param array<string, string> $headers
+     *
+     * @return list<Finding>
+     */
+    private function analyzeCorp(array $headers): array
+    {
+        if (!isset($headers['cross-origin-resource-policy'])) {
+            return [new Finding(
+                'Cross-Origin-Resource-Policy',
+                FindingSeverity::INFO,
+                'CORP header is missing',
+                'Add Cross-Origin-Resource-Policy: same-origin to prevent cross-origin reads of your resources',
+            )];
+        }
+
+        return [];
+    }
+
+    /**
+     * Normalize header names to lowercase for case-insensitive matching
+     *
+     * @param array<string, string> $headers
+     *
+     * @return array<string, string>
+     */
+    private function normalizeHeaders(array $headers): array
+    {
+        $normalized = [];
+
+        foreach ($headers as $name => $value) {
+            $normalized[strtolower($name)] = $value;
+        }
+
+        return $normalized;
+    }
+
+    /**
+     * Parse CSP header value into directive => sources map
+     *
+     * @return array<string, string>
+     */
+    private function parseCspDirectives(string $csp): array
+    {
+        $directives = [];
+
+        foreach (explode(';', $csp) as $part) {
+            $part = trim($part);
+
+            if ($part === '') {
+                continue;
+            }
+
+            $spacePos = strpos($part, ' ');
+
+            if ($spacePos === false) {
+                $directives[strtolower($part)] = '';
+            } else {
+                $name              = strtolower(substr($part, 0, $spacePos));
+                $directives[$name] = substr($part, $spacePos + 1);
+            }
+        }
+
+        return $directives;
+    }
+}

--- a/tests/Headers/Analyzer/SecurityHeaderAnalyzerTest.php
+++ b/tests/Headers/Analyzer/SecurityHeaderAnalyzerTest.php
@@ -1,0 +1,538 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Headers\Analyzer;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Zappzarapp\Security\Headers\Analyzer\AnalysisResult;
+use Zappzarapp\Security\Headers\Analyzer\Finding;
+use Zappzarapp\Security\Headers\Analyzer\FindingSeverity;
+use Zappzarapp\Security\Headers\Analyzer\SecurityHeaderAnalyzer;
+
+#[CoversClass(SecurityHeaderAnalyzer::class)]
+#[CoversClass(AnalysisResult::class)]
+#[CoversClass(Finding::class)]
+#[UsesClass(FindingSeverity::class)]
+final class SecurityHeaderAnalyzerTest extends TestCase
+{
+    private SecurityHeaderAnalyzer $analyzer;
+
+    protected function setUp(): void
+    {
+        $this->analyzer = new SecurityHeaderAnalyzer();
+    }
+
+    // === Full Analysis ===
+
+    #[Test]
+    public function testEmptyHeadersReportsAllMissing(): void
+    {
+        $result = $this->analyzer->analyze([]);
+
+        $this->assertFalse($result->isClean());
+        $this->assertTrue($result->hasHighOrAbove());
+        $this->assertGreaterThanOrEqual(9, $result->count());
+    }
+
+    #[Test]
+    public function testStrictHeadersAreClean(): void
+    {
+        $result = $this->analyzer->analyze([
+            'Strict-Transport-Security'    => 'max-age=63072000; includeSubDomains',
+            'Content-Security-Policy'      => "default-src 'self'",
+            'X-Frame-Options'              => 'DENY',
+            'X-Content-Type-Options'       => 'nosniff',
+            'Referrer-Policy'              => 'strict-origin-when-cross-origin',
+            'Permissions-Policy'           => 'camera=(), microphone=()',
+            'Cross-Origin-Opener-Policy'   => 'same-origin',
+            'Cross-Origin-Embedder-Policy' => 'require-corp',
+            'Cross-Origin-Resource-Policy' => 'same-origin',
+        ]);
+
+        $this->assertTrue($result->isClean());
+        $this->assertSame(0, $result->count());
+    }
+
+    #[Test]
+    public function testCaseInsensitiveHeaderMatching(): void
+    {
+        $result = $this->analyzer->analyze([
+            'strict-transport-security'    => 'max-age=63072000; includeSubDomains',
+            'content-security-policy'      => "default-src 'self'",
+            'x-frame-options'              => 'DENY',
+            'x-content-type-options'       => 'nosniff',
+            'referrer-policy'              => 'strict-origin-when-cross-origin',
+            'permissions-policy'           => 'camera=()',
+            'cross-origin-opener-policy'   => 'same-origin',
+            'cross-origin-embedder-policy' => 'require-corp',
+            'cross-origin-resource-policy' => 'same-origin',
+        ]);
+
+        $this->assertTrue($result->isClean());
+    }
+
+    // === HSTS ===
+
+    #[Test]
+    public function testMissingHstsIsHigh(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::HIGH, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testHstsLowMaxAge(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', 'max-age=3600; includeSubDomains');
+
+        $this->assertNotEmpty($findings);
+        $this->assertSame(FindingSeverity::MEDIUM, $findings[0]->severity);
+        $this->assertStringContainsString('3600', $findings[0]->message);
+    }
+
+    #[Test]
+    public function testHstsMissingIncludeSubDomains(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', 'max-age=63072000');
+
+        $this->assertNotEmpty($findings);
+
+        $finding = $this->findFindingWithMessage($findings, 'includeSubDomains');
+
+        $this->assertNotNull($finding);
+        $this->assertSame(FindingSeverity::MEDIUM, $finding->severity);
+    }
+
+    #[Test]
+    public function testHstsLowMaxAgeAndMissingIncludeSubDomains(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', 'max-age=3600');
+
+        $this->assertCount(2, $findings);
+    }
+
+    #[Test]
+    public function testHstsExactMinMaxAgeIsAccepted(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', 'max-age=31536000; includeSubDomains');
+
+        $this->assertEmpty($findings);
+    }
+
+    #[Test]
+    public function testHstsCaseInsensitiveMaxAge(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', 'Max-Age=3600; includeSubDomains');
+
+        $this->assertNotEmpty($findings);
+        $this->assertStringContainsString('3600', $findings[0]->message);
+    }
+
+    #[Test]
+    public function testHstsValidConfig(): void
+    {
+        $findings = $this->analyzeHeader('Strict-Transport-Security', 'max-age=63072000; includeSubDomains; preload');
+
+        $this->assertEmpty($findings);
+    }
+
+    // === CSP ===
+
+    #[Test]
+    public function testMissingCspIsHigh(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::HIGH, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testCspMissingDefaultSrc(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "script-src 'self'");
+
+        $finding = $this->findFindingWithMessage($findings, 'default-src');
+
+        $this->assertNotNull($finding);
+        $this->assertSame(FindingSeverity::MEDIUM, $finding->severity);
+    }
+
+    #[Test]
+    public function testCspUnsafeInlineInScriptSrc(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-inline'");
+
+        $finding = $this->findFindingWithMessage($findings, 'unsafe-inline');
+
+        $this->assertNotNull($finding);
+        $this->assertSame(FindingSeverity::HIGH, $finding->severity);
+    }
+
+    #[Test]
+    public function testCspUnsafeEvalInScriptSrc(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src 'self'; script-src 'self' 'unsafe-eval'");
+
+        $finding = $this->findFindingWithMessage($findings, 'unsafe-eval');
+
+        $this->assertNotNull($finding);
+        $this->assertSame(FindingSeverity::HIGH, $finding->severity);
+    }
+
+    #[Test]
+    public function testCspUnsafeInlineInStyleSrcIsMedium(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src 'self'; style-src 'self' 'unsafe-inline'");
+
+        $finding = $this->findFindingWithMessage($findings, 'style-src');
+
+        $this->assertNotNull($finding);
+        $this->assertSame(FindingSeverity::MEDIUM, $finding->severity);
+    }
+
+    #[Test]
+    public function testCspWildcardSource(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src *");
+
+        $finding = $this->findFindingWithMessage($findings, 'wildcard');
+
+        $this->assertNotNull($finding);
+        $this->assertSame(FindingSeverity::HIGH, $finding->severity);
+    }
+
+    #[Test]
+    public function testCspUnsafeInlineInStyleSrcFallsBackToDefaultSrc(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src 'self' 'unsafe-inline'; script-src 'self'");
+
+        $styleFinding = $this->findFindingWithMessage($findings, 'style-src');
+
+        $this->assertNotNull($styleFinding);
+        $this->assertSame(FindingSeverity::MEDIUM, $styleFinding->severity);
+    }
+
+    #[Test]
+    public function testCspUppercaseDirectiveNames(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "DEFAULT-SRC 'self'; SCRIPT-SRC 'self' 'unsafe-inline'");
+
+        $finding = $this->findFindingWithMessage($findings, 'unsafe-inline');
+
+        $this->assertNotNull($finding);
+    }
+
+    #[Test]
+    public function testCspValidPolicy(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src 'none'; script-src 'self'; style-src 'self'");
+
+        $this->assertEmpty($findings);
+    }
+
+    #[Test]
+    public function testCspDirectiveSourcesAreCorrectlyParsed(): void
+    {
+        // script-src has 'self' but NOT 'unsafe-inline' — the directive name
+        // must not leak into the sources
+        $findings = $this->analyzeHeader(
+            'Content-Security-Policy',
+            "default-src 'none'; script-src 'self' https://cdn.example.com",
+        );
+
+        $unsafeFinding = $this->findFindingWithMessage($findings, 'unsafe-inline');
+
+        $this->assertNull($unsafeFinding);
+    }
+
+    #[Test]
+    public function testCspUnsafeInlineInheritedFromDefaultSrc(): void
+    {
+        $findings = $this->analyzeHeader('Content-Security-Policy', "default-src 'self' 'unsafe-inline'");
+
+        $this->assertNotEmpty($findings);
+
+        $finding = $this->findFindingWithMessage($findings, 'script-src');
+
+        $this->assertNotNull($finding);
+    }
+
+    // === X-Frame-Options ===
+
+    #[Test]
+    public function testMissingXFrameOptionsIsMedium(): void
+    {
+        $findings = $this->analyzeHeader('X-Frame-Options', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::MEDIUM, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testXFrameOptionsDeny(): void
+    {
+        $findings = $this->analyzeHeader('X-Frame-Options', 'DENY');
+
+        $this->assertEmpty($findings);
+    }
+
+    #[Test]
+    public function testXFrameOptionsSameorigin(): void
+    {
+        $findings = $this->analyzeHeader('X-Frame-Options', 'SAMEORIGIN');
+
+        $this->assertEmpty($findings);
+    }
+
+    // === X-Content-Type-Options ===
+
+    #[Test]
+    public function testMissingXContentTypeOptionsIsMedium(): void
+    {
+        $findings = $this->analyzeHeader('X-Content-Type-Options', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::MEDIUM, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testXContentTypeOptionsNosniff(): void
+    {
+        $findings = $this->analyzeHeader('X-Content-Type-Options', 'nosniff');
+
+        $this->assertEmpty($findings);
+    }
+
+    #[Test]
+    public function testXContentTypeOptionsNosniffCaseInsensitive(): void
+    {
+        $findings = $this->analyzeHeader('X-Content-Type-Options', ' Nosniff ');
+
+        $this->assertEmpty($findings);
+    }
+
+    #[Test]
+    public function testXContentTypeOptionsInvalidValue(): void
+    {
+        $findings = $this->analyzeHeader('X-Content-Type-Options', 'none');
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::MEDIUM, $findings[0]->severity);
+    }
+
+    // === Referrer-Policy ===
+
+    #[Test]
+    public function testMissingReferrerPolicyIsLow(): void
+    {
+        $findings = $this->analyzeHeader('Referrer-Policy', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::LOW, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testReferrerPolicyUnsafeUrlIsHigh(): void
+    {
+        $findings = $this->analyzeHeader('Referrer-Policy', 'unsafe-url');
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::HIGH, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testReferrerPolicyNoReferrerWhenDowngradeIsLow(): void
+    {
+        $findings = $this->analyzeHeader('Referrer-Policy', 'no-referrer-when-downgrade');
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::LOW, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testReferrerPolicyUnsafeUrlCaseInsensitive(): void
+    {
+        $findings = $this->analyzeHeader('Referrer-Policy', ' Unsafe-URL ');
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::HIGH, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testReferrerPolicyStrictOriginWhenCrossOrigin(): void
+    {
+        $findings = $this->analyzeHeader('Referrer-Policy', 'strict-origin-when-cross-origin');
+
+        $this->assertEmpty($findings);
+    }
+
+    // === Permissions-Policy ===
+
+    #[Test]
+    public function testMissingPermissionsPolicyIsLow(): void
+    {
+        $findings = $this->analyzeHeader('Permissions-Policy', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::LOW, $findings[0]->severity);
+    }
+
+    #[Test]
+    public function testPermissionsPolicyPresent(): void
+    {
+        $findings = $this->analyzeHeader('Permissions-Policy', 'camera=(), microphone=()');
+
+        $this->assertEmpty($findings);
+    }
+
+    // === COOP ===
+
+    #[Test]
+    public function testMissingCoopIsLow(): void
+    {
+        $findings = $this->analyzeHeader('Cross-Origin-Opener-Policy', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::LOW, $findings[0]->severity);
+    }
+
+    // === COEP ===
+
+    #[Test]
+    public function testMissingCoepIsInfo(): void
+    {
+        $findings = $this->analyzeHeader('Cross-Origin-Embedder-Policy', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::INFO, $findings[0]->severity);
+    }
+
+    // === CORP ===
+
+    #[Test]
+    public function testMissingCorpIsInfo(): void
+    {
+        $findings = $this->analyzeHeader('Cross-Origin-Resource-Policy', null);
+
+        $this->assertCount(1, $findings);
+        $this->assertSame(FindingSeverity::INFO, $findings[0]->severity);
+    }
+
+    // === AnalysisResult ===
+
+    #[Test]
+    public function testResultForHeaderFiltersCorrectly(): void
+    {
+        $result = $this->analyzer->analyze([]);
+
+        $hstsFindings = $result->forHeader('Strict-Transport-Security');
+        $cspFindings  = $result->forHeader('Content-Security-Policy');
+
+        $this->assertCount(1, $hstsFindings);
+        $this->assertCount(1, $cspFindings);
+    }
+
+    #[Test]
+    public function testResultForHeaderIsCaseInsensitive(): void
+    {
+        $result = $this->analyzer->analyze([]);
+
+        $this->assertCount(1, $result->forHeader('strict-transport-security'));
+        $this->assertCount(1, $result->forHeader('STRICT-TRANSPORT-SECURITY'));
+    }
+
+    #[Test]
+    public function testResultHasCritical(): void
+    {
+        $result = new AnalysisResult(
+            new Finding('test', FindingSeverity::CRITICAL, 'msg', 'rec'),
+        );
+
+        $this->assertTrue($result->hasCritical());
+        $this->assertTrue($result->hasHighOrAbove());
+    }
+
+    #[Test]
+    public function testResultHasHighOrAbove(): void
+    {
+        $result = new AnalysisResult(
+            new Finding('test', FindingSeverity::HIGH, 'msg', 'rec'),
+        );
+
+        $this->assertFalse($result->hasCritical());
+        $this->assertTrue($result->hasHighOrAbove());
+    }
+
+    #[Test]
+    public function testResultIsClean(): void
+    {
+        $result = new AnalysisResult();
+
+        $this->assertTrue($result->isClean());
+        $this->assertSame(0, $result->count());
+    }
+
+    #[Test]
+    public function testFindingProperties(): void
+    {
+        $finding = new Finding('X-Frame-Options', FindingSeverity::HIGH, 'missing', 'add it');
+
+        $this->assertSame('X-Frame-Options', $finding->header);
+        $this->assertSame(FindingSeverity::HIGH, $finding->severity);
+        $this->assertSame('missing', $finding->message);
+        $this->assertSame('add it', $finding->recommendation);
+    }
+
+    // === Helpers ===
+
+    /**
+     * Analyze headers with all secure defaults except the given header
+     *
+     * @return list<Finding>
+     */
+    private function analyzeHeader(string $header, ?string $value): array
+    {
+        $secureDefaults = [
+            'Strict-Transport-Security'    => 'max-age=63072000; includeSubDomains',
+            'Content-Security-Policy'      => "default-src 'self'",
+            'X-Frame-Options'              => 'DENY',
+            'X-Content-Type-Options'       => 'nosniff',
+            'Referrer-Policy'              => 'strict-origin-when-cross-origin',
+            'Permissions-Policy'           => 'camera=()',
+            'Cross-Origin-Opener-Policy'   => 'same-origin',
+            'Cross-Origin-Embedder-Policy' => 'require-corp',
+            'Cross-Origin-Resource-Policy' => 'same-origin',
+        ];
+
+        if ($value === null) {
+            unset($secureDefaults[$header]);
+        } else {
+            $secureDefaults[$header] = $value;
+        }
+
+        $result = $this->analyzer->analyze($secureDefaults);
+
+        return $result->forHeader($header);
+    }
+
+    /**
+     * @param list<Finding> $findings
+     */
+    private function findFindingWithMessage(array $findings, string $substring): ?Finding
+    {
+        foreach ($findings as $finding) {
+            if (str_contains(strtolower($finding->message), strtolower($substring))) {
+                return $finding;
+            }
+        }
+
+        return null;
+    }
+}


### PR DESCRIPTION
## Summary
- Add `SecurityHeaderAnalyzer` that inspects HTTP response headers for missing, weak, or misconfigured security headers
- Returns structured `AnalysisResult` with `Finding` objects containing severity, message, and recommendation
- Checks: HSTS, CSP, X-Frame-Options, X-Content-Type-Options, Referrer-Policy, Permissions-Policy, COOP, COEP, CORP
- Add `docs/analyzer.md` with usage examples and CI integration guide
- Update `README.md` and `docs/index.md` module tables
- Add `HeadersAnalyzer` layer to `deptrac.yaml`

Closes #28

## Test plan
- [x] 36 tests covering all header checks, severities, and AnalysisResult API
- [x] PHPStan Level 8: no errors
- [x] Psalm Level 1: no errors
- [x] PHPMD: no violations
- [x] Rector: no suggestions
- [x] Deptrac: 0 violations
- [x] Pre-push hook: all quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)