### PR TITLE
feat: add PSR-15 middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Limiting, SRI, and Audit Logging.
 
 ## Highlights
 
-- **All-in-one** — 9 security modules in a single, composable package
+- **All-in-one** — 11 security modules in a single, composable package
 - **Secure by default** — strict CSP, no `unsafe-*`, HTTPS-first
 - **Framework-agnostic** — works with any PHP 8.4+ application
 - **Immutable & type-safe** — readonly classes, enums, `with*()` API
 - **Quality-backed** — PHPStan Level 8, Psalm Level 1, 100% Mutation Score,
   Deptrac architecture enforcement
-- **PSR-compatible** — PSR-3 (Logging), PSR-18 (HTTP Client)
+- **PSR-compatible** — PSR-3 (Logging), PSR-15 (Middleware), PSR-18 (HTTP Client)
 
 ## Modules
 
@@ -32,6 +32,7 @@ Limiting, SRI, and Audit Logging.
 | **RateLimiting** | Rate limiting with multiple algorithms            | `DefaultRateLimiter`, `RateLimitConfig`                            |
 | **SRI**          | Subresource Integrity hash generation             | `SriHashGenerator`, `IntegrityAttribute`                           |
 | **Analyzer**     | Security header analysis and auditing             | `SecurityHeaderAnalyzer`, `AnalysisResult`                         |
+| **Middleware**   | PSR-15 middleware for drop-in framework integration | `SecurityHeadersMiddleware`, `CsrfMiddleware`, `RateLimitMiddleware` |
 | **Logging**      | Security event audit logging                      | `SecurityAuditLogger`, `SecurityEvent`                             |
 
 ## Requirements
@@ -128,6 +129,7 @@ options, and code examples:
 | [Rate Limiting](docs/rate-limiting.md)    | Token bucket, sliding window        |
 | [SRI](docs/sri.md)                        | Subresource integrity hashes        |
 | [Analyzer](docs/analyzer.md)             | Security header auditing            |
+| [Middleware](docs/middleware.md)          | PSR-15 middleware                   |
 | [Logging](docs/logging.md)               | Security audit logging              |
 | [Glossary](docs/glossary.md)             | Security terminology reference      |
 

--- a/composer.json
+++ b/composer.json
@@ -43,7 +43,9 @@
     "ext-redis": "For Redis rate limit storage (phpredis extension)",
     "predis/predis": "For Redis rate limit storage (pure PHP client)",
     "ext-memcached": "For Memcached rate limit storage",
-    "ext-pdo": "For PDO rate limit storage (MySQL, PostgreSQL, SQLite)"
+    "ext-pdo": "For PDO rate limit storage (MySQL, PostgreSQL, SQLite)",
+    "psr/http-server-middleware": "For PSR-15 middleware support",
+    "psr/http-server-handler": "For PSR-15 middleware support"
   },
   "require-dev": {
     "ext-fileinfo": "*",
@@ -64,7 +66,9 @@
     "deptrac/deptrac": "^4.5",
     "captainhook/captainhook": "*",
     "captainhook/plugin-composer": "^5.3",
-    "giorgiosironi/eris": "^1.0"
+    "giorgiosironi/eris": "^1.0",
+    "psr/http-server-middleware": "^1.0",
+    "psr/http-server-handler": "^1.0"
   },
   "config": {
     "allow-plugins": {
@@ -87,7 +91,8 @@
       "Zappzarapp\\Security\\Sanitization\\": "src/Sanitization/",
       "Zappzarapp\\Security\\RateLimiting\\": "src/RateLimiting/",
       "Zappzarapp\\Security\\Sri\\": "src/Sri/",
-      "Zappzarapp\\Security\\Logging\\": "src/Logging/"
+      "Zappzarapp\\Security\\Logging\\": "src/Logging/",
+      "Zappzarapp\\Security\\Middleware\\": "src/Middleware/"
     }
   },
   "autoload-dev": {
@@ -100,7 +105,8 @@
       "Zappzarapp\\Security\\Tests\\Sanitization\\": "tests/Sanitization/",
       "Zappzarapp\\Security\\Tests\\RateLimiting\\": "tests/RateLimiting/",
       "Zappzarapp\\Security\\Tests\\Sri\\": "tests/Sri/",
-      "Zappzarapp\\Security\\Tests\\Logging\\": "tests/Logging/"
+      "Zappzarapp\\Security\\Tests\\Logging\\": "tests/Logging/",
+      "Zappzarapp\\Security\\Tests\\Middleware\\": "tests/Middleware/"
     }
   },
   "scripts": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4490a1891ae2e3ecd929ed52767cf224",
+    "content-hash": "5eb8918f35e0ac9515e3363ffe3f14c6",
     "packages": [],
     "packages-dev": [
         {
@@ -6798,6 +6798,119 @@
                 "source": "https://github.com/php-fig/http-message/tree/2.0"
             },
             "time": "2023-04-04T09:54:51+00:00"
+        },
+        {
+            "name": "psr/http-server-handler",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-handler.git",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-handler/zipball/84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "reference": "84c4fb66179be4caaf8e97bd239203245302e7d4",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side request handler",
+            "keywords": [
+                "handler",
+                "http",
+                "http-interop",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response",
+                "server"
+            ],
+            "support": {
+                "source": "https://github.com/php-fig/http-server-handler/tree/1.0.2"
+            },
+            "time": "2023-04-10T20:06:20+00:00"
+        },
+        {
+            "name": "psr/http-server-middleware",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/http-server-middleware.git",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/http-server-middleware/zipball/c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "reference": "c1481f747daaa6a0782775cd6a8c26a1bf4a3829",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=7.0",
+                "psr/http-message": "^1.0 || ^2.0",
+                "psr/http-server-handler": "^1.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Http\\Server\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "https://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for HTTP server-side middleware",
+            "keywords": [
+                "http",
+                "http-interop",
+                "middleware",
+                "psr",
+                "psr-15",
+                "psr-7",
+                "request",
+                "response"
+            ],
+            "support": {
+                "issues": "https://github.com/php-fig/http-server-middleware/issues",
+                "source": "https://github.com/php-fig/http-server-middleware/tree/1.0.2"
+            },
+            "time": "2023-04-11T06:14:47+00:00"
         },
         {
             "name": "psr/log",

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -290,6 +290,14 @@ deptrac:
           value: src/Logging/
 
     # ==========================================
+    # Middleware Module
+    # ==========================================
+    - name: Middleware
+      collectors:
+        - type: directory
+          value: src/Middleware/
+
+    # ==========================================
     # External Dependencies (PSR interfaces)
     # ==========================================
     - name: External
@@ -428,6 +436,19 @@ deptrac:
 
     # Logging Module Rules (depends on PSR-3 LoggerInterface)
     Logging:
+      - External
+
+    # Middleware Module Rules
+    Middleware:
+      - HeadersBuilder
+      - HeadersMain
+      - CspHeaderBuilder
+      - CspDirective
+      - CspNonce
+      - CsrfMain
+      - CsrfException
+      - RateLimitingMain
+      - RateLimitingException
       - External
 
     # External layer has no internal dependencies

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,7 @@ vulnerabilities.
 | [Rate Limiting](rate-limiting.md) | Token bucket and sliding window rate limiting with storage backends                        |
 | [SRI](sri.md)                     | Subresource Integrity hash generation and verification with SSRF protection                |
 | [Analyzer](analyzer.md)           | Security header analyzer for auditing and CI integration                                   |
+| [Middleware](middleware.md)       | PSR-15 middleware for security headers, CSP, CSRF, and rate limiting                       |
 | [Logging](logging.md)             | Security audit logging with correlation IDs                                                |
 | [Glossary](glossary.md)           | Security terms and concepts explained                                                      |
 

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -1,0 +1,139 @@
+# PSR-15 Middleware
+
+Drop-in PSR-15 middleware for any compliant framework (Slim, Mezzio, Laravel via
+bridge, etc.).
+
+## Installation
+
+The middleware requires PSR-15 and PSR-7 packages:
+
+```bash
+composer require psr/http-server-middleware psr/http-server-handler
+```
+
+## Security Headers Middleware
+
+Applies all configured security headers to responses.
+
+```php
+use Zappzarapp\Security\Headers\SecurityHeaders;
+use Zappzarapp\Security\Middleware\SecurityHeadersMiddleware;
+
+$middleware = new SecurityHeadersMiddleware(SecurityHeaders::strict());
+
+// In Slim:
+$app->add($middleware);
+```
+
+## CSP Middleware
+
+Injects Content-Security-Policy headers with nonce support. The `NonceProvider`
+is stored in the request attribute `csp-nonce` for template access.
+
+```php
+use Zappzarapp\Security\Csp\Directive\CspDirectives;
+use Zappzarapp\Security\Middleware\CspMiddleware;
+
+$middleware = new CspMiddleware(CspDirectives::strict());
+
+// In Slim:
+$app->add($middleware);
+```
+
+### Accessing the Nonce in Templates
+
+```php
+// In a PSR-15 handler or controller:
+$nonce = $request->getAttribute('csp-nonce')->get();
+echo "<script nonce=\"{$nonce}\">...</script>";
+```
+
+### Report-Only Mode
+
+```php
+$middleware = new CspMiddleware(
+    directives: CspDirectives::strict(),
+    reportOnly: true,
+);
+```
+
+## CSRF Middleware
+
+Validates CSRF tokens on state-changing requests (POST, PUT, DELETE, PATCH).
+Safe methods (GET, HEAD, OPTIONS) pass through with the token stored in
+request attribute `csrf-token`.
+
+```php
+use Zappzarapp\Security\Csrf\CsrfProtection;
+use Zappzarapp\Security\Csrf\Storage\SessionCsrfStorage;
+use Zappzarapp\Security\Middleware\CsrfMiddleware;
+
+$protection = CsrfProtection::synchronizer(new SessionCsrfStorage());
+$middleware = new CsrfMiddleware($protection);
+
+// In Slim:
+$app->add($middleware);
+```
+
+### Token Source Priority
+
+1. Request header (configured via `CsrfConfig::headerName`, default: `X-CSRF-Token`)
+2. Parsed body field (configured via `CsrfConfig::fieldName`, default: `_csrf_token`)
+
+### Using the Token in Forms
+
+```php
+// In a PSR-15 handler:
+$token = $request->getAttribute('csrf-token');
+echo "<input type=\"hidden\" name=\"_csrf_token\" value=\"{$token}\">";
+```
+
+## Rate Limit Middleware
+
+Enforces rate limits and returns 429 responses when exceeded. Rate limit headers
+(`X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset`) are applied
+to all responses.
+
+```php
+use Zappzarapp\Security\Middleware\RateLimitMiddleware;
+use Zappzarapp\Security\RateLimiting\DefaultRateLimiter;
+
+$limiter    = DefaultRateLimiter::api();
+$middleware = new RateLimitMiddleware($limiter, $responseFactory);
+
+// In Slim:
+$app->add($middleware);
+```
+
+### Custom Identifier
+
+By default, the middleware identifies clients by IP address. Override with a
+custom extractor:
+
+```php
+$middleware = new RateLimitMiddleware(
+    limiter: $limiter,
+    responseFactory: $responseFactory,
+    identifierExtractor: fn ($request) => RateLimitIdentifier::fromUserId(
+        $request->getAttribute('user_id'),
+    ),
+);
+```
+
+## Combining Middleware
+
+Apply middleware in the correct order (outermost runs first):
+
+```php
+// Rate limiting first (cheapest check)
+$app->add(new RateLimitMiddleware($limiter, $responseFactory));
+
+// Then CSRF (blocks invalid state-changing requests)
+$app->add(new CsrfMiddleware($protection));
+
+// Then security headers (applied to all responses)
+$app->add(new SecurityHeadersMiddleware(SecurityHeaders::strict()));
+
+// Then CSP (adds nonce to request for handlers)
+$app->add(new CspMiddleware(CspDirectives::strict()));
+```

--- a/src/Middleware/CspMiddleware.php
+++ b/src/Middleware/CspMiddleware.php
@@ -1,0 +1,58 @@
+<?php
+
+/**
+ * @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive
+ * @noinspection PhpComposerExtensionStubsInspection psr/http-server-middleware is optional (suggest)
+ */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Middleware;
+
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Random\RandomException;
+use Zappzarapp\Security\Csp\Directive\CspDirectives;
+use Zappzarapp\Security\Csp\HeaderBuilder;
+use Zappzarapp\Security\Csp\Nonce\NonceGenerator;
+use Zappzarapp\Security\Csp\Nonce\NonceProvider;
+
+/**
+ * PSR-15 middleware that applies Content-Security-Policy headers
+ *
+ * Stores the NonceProvider in the request attribute 'csp-nonce' for template access.
+ */
+final readonly class CspMiddleware implements MiddlewareInterface
+{
+    public const string NONCE_ATTRIBUTE = 'csp-nonce';
+
+    private NonceProvider $nonceProvider;
+
+    public function __construct(
+        private CspDirectives $directives,
+        ?NonceProvider $nonceProvider = null,
+        private bool $reportOnly = false,
+    ) {
+        $this->nonceProvider = $nonceProvider ?? new NonceGenerator();
+    }
+
+    /**
+     * @throws RandomException
+     */
+    #[Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $request  = $request->withAttribute(self::NONCE_ATTRIBUTE, $this->nonceProvider);
+        $response = $handler->handle($request);
+
+        $headerValue = HeaderBuilder::build($this->directives, $this->nonceProvider);
+        $headerName  = $this->reportOnly
+            ? HeaderBuilder::HEADER_CSP_REPORT_ONLY
+            : HeaderBuilder::HEADER_CSP;
+
+        return $response->withHeader($headerName, $headerValue);
+    }
+}

--- a/src/Middleware/CsrfMiddleware.php
+++ b/src/Middleware/CsrfMiddleware.php
@@ -1,0 +1,90 @@
+<?php
+
+/**
+ * @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive
+ * @noinspection PhpComposerExtensionStubsInspection psr/http-server-middleware is optional (suggest)
+ */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Middleware;
+
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Random\RandomException;
+use Zappzarapp\Security\Csrf\CsrfProtection;
+use Zappzarapp\Security\Csrf\Exception\CsrfTokenMismatchException;
+use Zappzarapp\Security\Csrf\Exception\InvalidCsrfTokenException;
+
+/**
+ * PSR-15 middleware for CSRF protection (Synchronizer Token Pattern)
+ *
+ * Safe methods (GET, HEAD, OPTIONS) pass through with the CSRF token
+ * stored in the request attribute 'csrf-token'.
+ *
+ * State-changing methods (POST, PUT, DELETE, PATCH) validate the CSRF
+ * token from the request header or parsed body field.
+ *
+ * @throws CsrfTokenMismatchException When token validation fails
+ * @throws InvalidCsrfTokenException When token format is invalid
+ */
+final readonly class CsrfMiddleware implements MiddlewareInterface
+{
+    public const string TOKEN_ATTRIBUTE = 'csrf-token';
+
+    private const array SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
+    public function __construct(
+        private CsrfProtection $protection,
+    ) {
+    }
+
+    /**
+     * @throws RandomException
+     */
+    #[Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!in_array($request->getMethod(), self::SAFE_METHODS, true)) {
+            $this->validateToken($request);
+        }
+
+        $request = $request->withAttribute(self::TOKEN_ATTRIBUTE, $this->protection->token());
+
+        return $handler->handle($request);
+    }
+
+    /**
+     * @throws CsrfTokenMismatchException
+     * @throws InvalidCsrfTokenException
+     * @throws RandomException
+     */
+    private function validateToken(ServerRequestInterface $request): void
+    {
+        $token = $this->extractToken($request);
+
+        $this->protection->validate($token);
+    }
+
+    private function extractToken(ServerRequestInterface $request): string
+    {
+        $headerName = $this->protection->headerName();
+        $header     = $request->getHeaderLine($headerName);
+
+        if ($header !== '') {
+            return $header;
+        }
+
+        $fieldName = $this->protection->fieldName();
+        $body      = $request->getParsedBody();
+
+        if (is_array($body) && isset($body[$fieldName]) && is_string($body[$fieldName])) {
+            return $body[$fieldName];
+        }
+
+        throw CsrfTokenMismatchException::missingToken();
+    }
+}

--- a/src/Middleware/RateLimitMiddleware.php
+++ b/src/Middleware/RateLimitMiddleware.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ * @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive
+ * @noinspection PhpComposerExtensionStubsInspection psr/http-server-middleware is optional (suggest)
+ */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Middleware;
+
+use Closure;
+use Override;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zappzarapp\Security\RateLimiting\RateLimiter;
+use Zappzarapp\Security\RateLimiting\RateLimitIdentifier;
+
+/**
+ * PSR-15 middleware for rate limiting
+ *
+ * Enforces rate limits and returns 429 responses with Retry-After headers
+ * when the limit is exceeded. Rate limit headers are applied to all responses.
+ */
+final readonly class RateLimitMiddleware implements MiddlewareInterface
+{
+    /** @var Closure(ServerRequestInterface): (RateLimitIdentifier|string) */
+    private Closure $identifierExtractor;
+
+    /**
+     * @param RateLimiter $limiter Rate limiter instance
+     * @param ResponseFactoryInterface $responseFactory PSR-17 response factory for 429 responses
+     * @param (callable(ServerRequestInterface): (RateLimitIdentifier|string))|null $identifierExtractor Custom identifier extractor, defaults to IP-based
+     */
+    public function __construct(
+        private RateLimiter $limiter,
+        private ResponseFactoryInterface $responseFactory,
+        ?callable $identifierExtractor = null,
+    ) {
+        $this->identifierExtractor = $identifierExtractor !== null
+            ? $identifierExtractor(...)
+            : static fn (ServerRequestInterface $request): RateLimitIdentifier => RateLimitIdentifier::fromIp(
+                (string) ($request->getServerParams()['REMOTE_ADDR'] ?? '127.0.0.1'),
+            );
+    }
+
+    #[Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $identifier = ($this->identifierExtractor)($request);
+        $result     = $this->limiter->consume($identifier);
+
+        if ($result->isDenied()) {
+            $response = $this->responseFactory->createResponse(429);
+
+            foreach ($result->toHeaders() as $name => $value) {
+                $response = $response->withHeader($name, $value);
+            }
+
+            return $response;
+        }
+
+        $response = $handler->handle($request);
+
+        foreach ($result->toHeaders() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response;
+    }
+}

--- a/src/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Middleware/SecurityHeadersMiddleware.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive
+ * @noinspection PhpComposerExtensionStubsInspection psr/http-server-middleware is optional (suggest)
+ */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Middleware;
+
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Random\RandomException;
+use Zappzarapp\Security\Headers\Builder\SecurityHeadersBuilder;
+use Zappzarapp\Security\Headers\SecurityHeaders;
+
+/**
+ * PSR-15 middleware that applies security headers to responses
+ */
+final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
+{
+    private SecurityHeadersBuilder $builder;
+
+    public function __construct(SecurityHeaders $headers)
+    {
+        $this->builder = SecurityHeadersBuilder::from($headers);
+    }
+
+    /**
+     * @throws RandomException
+     */
+    #[Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        $response = $handler->handle($request);
+
+        foreach ($this->builder->build() as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response;
+    }
+}

--- a/tests/Middleware/CspMiddlewareTest.php
+++ b/tests/Middleware/CspMiddlewareTest.php
@@ -1,0 +1,134 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection Tests may throw RandomException */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zappzarapp\Security\Csp\Directive\CspDirectives;
+use Zappzarapp\Security\Csp\HeaderBuilder;
+use Zappzarapp\Security\Csp\Nonce\NonceGenerator;
+use Zappzarapp\Security\Csp\Nonce\NonceProvider;
+use Zappzarapp\Security\Middleware\CspMiddleware;
+
+#[CoversClass(CspMiddleware::class)]
+#[UsesClass(CspDirectives::class)]
+#[UsesClass(HeaderBuilder::class)]
+#[UsesClass(NonceGenerator::class)]
+final class CspMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function testAppliesCspHeader(): void
+    {
+        $directives = CspDirectives::strict();
+        $middleware = new CspMiddleware($directives);
+
+        $appliedHeaders = [];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
+                $appliedHeaders[$name] = $value;
+
+                return $response;
+            });
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('withAttribute')->willReturn($request);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($request, $handler);
+
+        $this->assertArrayHasKey('Content-Security-Policy', $appliedHeaders);
+        $this->assertStringContainsString("default-src 'self'", $appliedHeaders['Content-Security-Policy']);
+    }
+
+    #[Test]
+    public function testReportOnlyMode(): void
+    {
+        $directives = CspDirectives::strict();
+        $middleware = new CspMiddleware($directives, reportOnly: true);
+
+        $appliedHeaders = [];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
+                $appliedHeaders[$name] = $value;
+
+                return $response;
+            });
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('withAttribute')->willReturn($request);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($request, $handler);
+
+        $this->assertArrayHasKey('Content-Security-Policy-Report-Only', $appliedHeaders);
+        $this->assertArrayNotHasKey('Content-Security-Policy', $appliedHeaders);
+    }
+
+    #[Test]
+    public function testStoresNonceProviderInRequestAttribute(): void
+    {
+        $nonce      = $this->createStub(NonceProvider::class);
+        $directives = CspDirectives::strict();
+        $middleware = new CspMiddleware($directives, $nonce);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->expects($this->once())
+            ->method('withAttribute')
+            ->with(CspMiddleware::NONCE_ATTRIBUTE, $nonce)
+            ->willReturn($request);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testCreatesNonceGeneratorWhenNoneProvided(): void
+    {
+        $directives = CspDirectives::strict();
+        $middleware = new CspMiddleware($directives);
+
+        $storedProvider = null;
+
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('withAttribute')
+            ->willReturnCallback(function (string $name, mixed $value) use (&$storedProvider, $request): ServerRequestInterface {
+                if ($name === CspMiddleware::NONCE_ATTRIBUTE) {
+                    $storedProvider = $value;
+                }
+
+                return $request;
+            });
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($request, $handler);
+
+        $this->assertInstanceOf(NonceProvider::class, $storedProvider);
+    }
+}

--- a/tests/Middleware/CsrfMiddlewareTest.php
+++ b/tests/Middleware/CsrfMiddlewareTest.php
@@ -1,0 +1,230 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection Tests may throw RandomException */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zappzarapp\Security\Csrf\CsrfConfig;
+use Zappzarapp\Security\Csrf\CsrfProtection;
+use Zappzarapp\Security\Csrf\Exception\CsrfTokenMismatchException;
+use Zappzarapp\Security\Csrf\Exception\InvalidCsrfTokenException;
+use Zappzarapp\Security\Csrf\Storage\ArrayCsrfStorage;
+use Zappzarapp\Security\Csrf\Token\CsrfToken;
+use Zappzarapp\Security\Csrf\Token\CsrfTokenGenerator;
+use Zappzarapp\Security\Middleware\CsrfMiddleware;
+
+#[CoversClass(CsrfMiddleware::class)]
+#[UsesClass(CsrfProtection::class)]
+#[UsesClass(CsrfConfig::class)]
+#[UsesClass(ArrayCsrfStorage::class)]
+#[UsesClass(CsrfToken::class)]
+#[UsesClass(CsrfTokenGenerator::class)]
+#[UsesClass(CsrfTokenMismatchException::class)]
+final class CsrfMiddlewareTest extends TestCase
+{
+    private CsrfProtection $protection;
+
+    private CsrfMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->protection = CsrfProtection::synchronizer(new ArrayCsrfStorage());
+        $this->middleware = new CsrfMiddleware($this->protection);
+    }
+
+    #[Test]
+    public function testGetRequestPassesThrough(): void
+    {
+        $request  = $this->createRequest('GET');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testHeadRequestPassesThrough(): void
+    {
+        $request  = $this->createRequest('HEAD');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($response, $result);
+    }
+
+    #[Test]
+    public function testOptionsRequestPassesThrough(): void
+    {
+        $request  = $this->createRequest('OPTIONS');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $result = $this->middleware->process($request, $handler);
+
+        $this->assertSame($response, $result);
+    }
+
+    #[Test]
+    public function testStoresTokenInRequestAttribute(): void
+    {
+        $request  = $this->createRequest('GET');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $storedToken = null;
+
+        $request->method('withAttribute')
+            ->willReturnCallback(function (string $name, mixed $value) use (&$storedToken, $request): ServerRequestInterface {
+                if ($name === CsrfMiddleware::TOKEN_ATTRIBUTE) {
+                    $storedToken = $value;
+                }
+
+                return $request;
+            });
+
+        $this->middleware->process($request, $handler);
+
+        $this->assertInstanceOf(CsrfToken::class, $storedToken);
+    }
+
+    #[Test]
+    public function testPostRequestValidatesTokenFromHeader(): void
+    {
+        $token = $this->protection->token();
+
+        $request  = $this->createRequest('POST', headerToken: (string) $token);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostRequestValidatesTokenFromBody(): void
+    {
+        $token = $this->protection->token();
+
+        $request  = $this->createRequest('POST', bodyToken: (string) $token);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostRequestThrowsOnMissingToken(): void
+    {
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request  = $this->createRequest('POST');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostRequestThrowsOnInvalidToken(): void
+    {
+        // Generate a valid token first so there's something stored
+        $this->protection->token();
+
+        $this->expectException(InvalidCsrfTokenException::class);
+
+        $request  = $this->createRequest('POST', headerToken: 'invalid-token');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testDeleteRequestRequiresToken(): void
+    {
+        $token = $this->protection->token();
+
+        $request  = $this->createRequest('DELETE', headerToken: (string) $token);
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPutRequestRequiresToken(): void
+    {
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request  = $this->createRequest('PUT');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testHeaderTokenTakesPriorityOverBody(): void
+    {
+        $token = $this->protection->token();
+
+        // Both header and body have tokens, header should be used
+        $request  = $this->createRequest('POST', headerToken: (string) $token, bodyToken: 'wrong-token');
+        $response = $this->createStub(ResponseInterface::class);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    private function createRequest(
+        string $method,
+        ?string $headerToken = null,
+        ?string $bodyToken = null,
+    ): ServerRequestInterface&MockObject {
+        $request = $this->createMock(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn($method);
+        $request->method('withAttribute')->willReturn($request);
+        $request->method('getHeaderLine')
+            ->willReturnCallback(fn (string $name): string => $name === $this->protection->headerName() && $headerToken !== null
+                ? $headerToken
+                : '');
+
+        $body = $bodyToken !== null ? [$this->protection->fieldName() => $bodyToken] : [];
+        $request->method('getParsedBody')->willReturn($body);
+
+        return $request;
+    }
+}

--- a/tests/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/Middleware/RateLimitMiddlewareTest.php
@@ -1,0 +1,176 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection Tests may throw RandomException */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseFactoryInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zappzarapp\Security\Middleware\RateLimitMiddleware;
+use Zappzarapp\Security\RateLimiting\DefaultRateLimiter;
+use Zappzarapp\Security\RateLimiting\RateLimitConfig;
+use Zappzarapp\Security\RateLimiting\RateLimiter;
+use Zappzarapp\Security\RateLimiting\RateLimitIdentifier;
+use Zappzarapp\Security\RateLimiting\RateLimitResult;
+use Zappzarapp\Security\RateLimiting\Storage\InMemoryStorage;
+
+#[CoversClass(RateLimitMiddleware::class)]
+#[UsesClass(DefaultRateLimiter::class)]
+#[UsesClass(RateLimitConfig::class)]
+#[UsesClass(RateLimitIdentifier::class)]
+#[UsesClass(RateLimitResult::class)]
+#[UsesClass(InMemoryStorage::class)]
+final class RateLimitMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function testAllowedRequestPassesThrough(): void
+    {
+        $limiter    = new DefaultRateLimiter(new RateLimitConfig(limit: 10, window: 60));
+        $middleware = new RateLimitMiddleware($limiter, $this->createResponseFactory());
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $request = $this->createRequest('127.0.0.1');
+
+        $middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testDeniedRequestReturns429WithHeaders(): void
+    {
+        $result = RateLimitResult::denied(10, time() + 60, 60);
+
+        $limiter = $this->createMock(RateLimiter::class);
+        $limiter->method('consume')->willReturn($result);
+
+        $appliedHeaders = [];
+
+        $deniedResponse = $this->createMock(ResponseInterface::class);
+        $deniedResponse->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $deniedResponse): ResponseInterface {
+                $appliedHeaders[$name] = $value;
+
+                return $deniedResponse;
+            });
+
+        $responseFactory = $this->createMock(ResponseFactoryInterface::class);
+        $responseFactory->expects($this->once())
+            ->method('createResponse')
+            ->with(429)
+            ->willReturn($deniedResponse);
+
+        $middleware = new RateLimitMiddleware($limiter, $responseFactory);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->never())->method('handle');
+
+        $middleware->process($this->createRequest('127.0.0.1'), $handler);
+
+        $this->assertArrayHasKey('Retry-After', $appliedHeaders);
+        $this->assertArrayHasKey('X-RateLimit-Limit', $appliedHeaders);
+    }
+
+    #[Test]
+    public function testAppliesRateLimitHeaders(): void
+    {
+        $limiter    = new DefaultRateLimiter(new RateLimitConfig(limit: 10, window: 60));
+        $middleware = new RateLimitMiddleware($limiter, $this->createResponseFactory());
+
+        $appliedHeaders = [];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
+                $appliedHeaders[$name] = $value;
+
+                return $response;
+            });
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($this->createRequest('127.0.0.1'), $handler);
+
+        $this->assertArrayHasKey('X-RateLimit-Limit', $appliedHeaders);
+        $this->assertArrayHasKey('X-RateLimit-Remaining', $appliedHeaders);
+        $this->assertArrayHasKey('X-RateLimit-Reset', $appliedHeaders);
+    }
+
+    #[Test]
+    public function testCustomIdentifierExtractor(): void
+    {
+        $result = RateLimitResult::allowed(10, 9, time() + 60);
+
+        $limiter = $this->createMock(RateLimiter::class);
+        $limiter->expects($this->once())
+            ->method('consume')
+            ->with('custom:api-key-123')
+            ->willReturn($result);
+
+        $extractor  = static fn (ServerRequestInterface $request): string => 'custom:api-key-123';
+        $middleware = new RateLimitMiddleware($limiter, $this->createResponseFactory(), $extractor);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($this->createRequest('127.0.0.1'), $handler);
+    }
+
+    #[Test]
+    public function testDefaultIdentifierUsesRemoteAddr(): void
+    {
+        $result = RateLimitResult::allowed(10, 9, time() + 60);
+
+        $limiter = $this->createMock(RateLimiter::class);
+        $limiter->expects($this->once())
+            ->method('consume')
+            ->with($this->callback(fn (mixed $id): bool => $id instanceof RateLimitIdentifier
+                && str_contains($id->value(), '192.168.1.1')))
+            ->willReturn($result);
+
+        $middleware = new RateLimitMiddleware($limiter, $this->createResponseFactory());
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($this->createRequest('192.168.1.1'), $handler);
+    }
+
+    private function createRequest(string $remoteAddr): ServerRequestInterface
+    {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getServerParams')->willReturn(['REMOTE_ADDR' => $remoteAddr]);
+
+        return $request;
+    }
+
+    private function createResponseFactory(): ResponseFactoryInterface
+    {
+        $factory = $this->createStub(ResponseFactoryInterface::class);
+
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $factory->method('createResponse')->willReturn($response);
+
+        return $factory;
+    }
+}

--- a/tests/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/Middleware/SecurityHeadersMiddlewareTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection Tests may throw RandomException */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Zappzarapp\Security\Headers\Builder\SecurityHeadersBuilder;
+use Zappzarapp\Security\Headers\Hsts\HstsConfig;
+use Zappzarapp\Security\Headers\SecurityHeaders;
+use Zappzarapp\Security\Middleware\SecurityHeadersMiddleware;
+
+#[CoversClass(SecurityHeadersMiddleware::class)]
+#[UsesClass(SecurityHeadersBuilder::class)]
+#[UsesClass(SecurityHeaders::class)]
+#[UsesClass(HstsConfig::class)]
+final class SecurityHeadersMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function testAppliesSecurityHeaders(): void
+    {
+        $headers    = SecurityHeaders::strict();
+        $middleware = new SecurityHeadersMiddleware($headers);
+
+        $appliedHeaders = [];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
+                $appliedHeaders[$name] = $value;
+
+                return $response;
+            });
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+
+        $middleware->process($request, $handler);
+
+        $this->assertArrayHasKey('Strict-Transport-Security', $appliedHeaders);
+        $this->assertArrayHasKey('X-Content-Type-Options', $appliedHeaders);
+    }
+
+    #[Test]
+    public function testPassesRequestToHandler(): void
+    {
+        $headers    = SecurityHeaders::development();
+        $middleware = new SecurityHeadersMiddleware($headers);
+
+        $request  = $this->createStub(ServerRequestInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withHeader')->willReturn($response);
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())
+            ->method('handle')
+            ->with($request)
+            ->willReturn($response);
+
+        $middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testDevelopmentHeadersApplyMinimalSet(): void
+    {
+        $headers    = SecurityHeaders::development();
+        $middleware = new SecurityHeadersMiddleware($headers);
+
+        $appliedHeaders = [];
+
+        $response = $this->createMock(ResponseInterface::class);
+        $response->method('withHeader')
+            ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
+                $appliedHeaders[$name] = $value;
+
+                return $response;
+            });
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $middleware->process($this->createStub(ServerRequestInterface::class), $handler);
+
+        $this->assertArrayHasKey('X-Content-Type-Options', $appliedHeaders);
+        $this->assertArrayNotHasKey('Strict-Transport-Security', $appliedHeaders);
+    }
+}


### PR DESCRIPTION
## Summary
- Add four PSR-15 `MiddlewareInterface` implementations for drop-in framework integration:
  - `SecurityHeadersMiddleware` — applies configured security headers to responses
  - `CspMiddleware` — injects CSP headers with nonce support (stored in request attribute `csp-nonce`)
  - `CsrfMiddleware` — validates CSRF tokens on state-changing requests (POST, PUT, DELETE, PATCH)
  - `RateLimitMiddleware` — enforces rate limits with 429 responses and `Retry-After` headers
- Add `psr/http-server-middleware` and `psr/http-server-handler` as `suggest` dependencies
- Add `docs/middleware.md` with usage examples and framework integration guide
- Update `README.md` (11 modules, PSR-15 in highlights) and `docs/index.md`
- Add `Middleware` layer to `deptrac.yaml`

Closes #26

## Test plan
- [x] 23 tests covering all 4 middleware (happy path, error cases, header application, attribute injection)
- [x] PHPStan Level 8: no errors
- [x] Psalm Level 1: no errors
- [x] PHPMD: no violations
- [x] Rector: no suggestions
- [x] Deptrac: 0 violations
- [x] Infection: 100% MSI
- [x] Pre-push hook: all quality checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)