### PR TITLE
fix(ci): audit lock file instead of empty prod install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,7 +115,7 @@ jobs:
         run: composer install --prefer-dist --no-progress --no-interaction
 
       - name: Security audit
-        run: composer audit --no-dev
+        run: composer audit --locked
 
       - name: Run PHPStan
         run: vendor/bin/phpstan analyse


### PR DESCRIPTION
## Problem

The `Security audit` step (`composer audit --no-dev`) fails with exit code 1:

```
No installed packages found. Please run "composer install" before running "audit" or pass "--locked" to audit the lock file.
```

This library has **no production dependencies** — `require` only lists `php` and extensions. With `--no-dev`, `composer audit` is left with zero installed packages and errors out.

master appeared green only because the `paths-filter` skips the PHP test jobs unless `src/**`, `composer.json` or `composer.lock` change. Recent merges (e.g. #58, release PRs) skipped the job entirely. Any PR touching `composer.lock` — like the open Dependabot PRs #55/#56/#57 — triggers the job and hits the broken step.

## Fix

Switch to `composer audit --locked`, which audits the full lock file (including dev dependencies) directly. This is Composer's own suggested remedy, decouples the audit from the install step, and still covers all dependencies — appropriate for a security-first library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)