### PR TITLE
fix(build): audit lock file in composer script and GitLab CI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -76,7 +76,7 @@ security:
   <<: *php-setup
   stage: test
   script:
-    - composer audit --no-dev
+    - composer audit --locked
 
 phpstan:
   <<: *php-setup

--- a/composer.json
+++ b/composer.json
@@ -118,7 +118,7 @@
     "rector-fix": "@php vendor/bin/rector process",
     "infection": "@php vendor/bin/infection --threads=4",
     "deptrac": "@php vendor/bin/deptrac analyse",
-    "security": "composer audit --no-dev",
+    "security": "composer audit --locked",
     "sbom": "@composer CycloneDX:make-sbom --output-file=sbom.json",
     "cs-fix": "@php vendor/bin/php-cs-fixer fix",
     "cs-check": "@php vendor/bin/php-cs-fixer fix --dry-run --diff",


### PR DESCRIPTION
## Summary

Fix the two remaining `composer audit --no-dev` call sites that share the bug already resolved in #59 (GitHub CI) and #61 (Makefile). With no production dependencies, `--no-dev` leaves zero installed packages and the audit fails with *"No installed packages found"*.

- `composer.json` → `scripts.security` (used by `composer check` / `composer check-full`)
- `.gitlab-ci.yml` → `security` job

Both now use `composer audit --locked`, auditing the full lock file — consistent with everywhere else.

🤖 Generated with [Claude Code](https://claude.com/claude-code)