### PR TITLE
feat(headers): add PSR-7 response support to SecurityHeaderAnalyzer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,7 @@
   },
   "suggest": {
     "psr/log": "For security event audit logging (PSR-3)",
+    "psr/http-message": "For PSR-7 response analysis in SecurityHeaderAnalyzer",
     "psr/http-client": "For PSR-18 HTTP client support in PwnedPasswordChecker",
     "psr/http-factory": "For PSR-17 HTTP factory support in PwnedPasswordChecker",
     "ext-redis": "For Redis rate limit storage (phpredis extension)",

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -339,7 +339,8 @@ deptrac:
     HeadersPermissionsPolicy:
       - HeadersException
       - HeadersValidation
-    HeadersAnalyzer: ~
+    HeadersAnalyzer:
+      - External
     HeadersBuilder:
       - HeadersMain
       - HeadersEnums

--- a/infection.json5
+++ b/infection.json5
@@ -549,7 +549,12 @@
                 // PDO getAttribute returns string anyway, cast is defensive
                 "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::__construct",
                 // PDO binds parameters as strings regardless of explicit cast
-                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::increment"
+                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::increment",
+                // EQUIVALENT: PSR-7 getHeaders() keys are always header-name strings;
+                // the cast only satisfies the int|string array-key type. Dropping it
+                // yields an identical array because non-numeric string keys are never
+                // coerced, so no test can distinguish the mutant.
+                "Zappzarapp\\Security\\Headers\\Analyzer\\SecurityHeaderAnalyzer::analyzeResponse"
             ]
         },
         "MatchArmRemoval": {

--- a/src/Headers/Analyzer/SecurityHeaderAnalyzer.php
+++ b/src/Headers/Analyzer/SecurityHeaderAnalyzer.php
@@ -1,8 +1,14 @@
 <?php
 
+/**
+ * @noinspection PhpComposerExtensionStubsInspection psr/http-message is optional (suggest)
+ */
+
 declare(strict_types=1);
 
 namespace Zappzarapp\Security\Headers\Analyzer;
+
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * Analyzes HTTP response headers for security issues
@@ -36,6 +42,22 @@ final class SecurityHeaderAnalyzer
         ];
 
         return new AnalysisResult(...$findings);
+    }
+
+    /**
+     * Analyze a PSR-7 response for security header issues
+     *
+     * Extracts the response headers and delegates to {@see analyze()}.
+     */
+    public function analyzeResponse(ResponseInterface $response): AnalysisResult
+    {
+        $headers = [];
+
+        foreach ($response->getHeaders() as $name => $values) {
+            $headers[(string) $name] = implode(', ', $values);
+        }
+
+        return $this->analyze($headers);
     }
 
     /**

--- a/tests/Headers/Analyzer/SecurityHeaderAnalyzerTest.php
+++ b/tests/Headers/Analyzer/SecurityHeaderAnalyzerTest.php
@@ -8,6 +8,7 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
 use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
 use Zappzarapp\Security\Headers\Analyzer\AnalysisResult;
 use Zappzarapp\Security\Headers\Analyzer\Finding;
 use Zappzarapp\Security\Headers\Analyzer\FindingSeverity;
@@ -425,6 +426,58 @@ final class SecurityHeaderAnalyzerTest extends TestCase
         $this->assertSame(FindingSeverity::INFO, $findings[0]->severity);
     }
 
+    // === PSR-7 Response ===
+
+    #[Test]
+    public function testAnalyzeResponseWithStrictHeadersIsClean(): void
+    {
+        $response = $this->responseWithHeaders([
+            'Strict-Transport-Security'    => ['max-age=63072000; includeSubDomains'],
+            'Content-Security-Policy'      => ["default-src 'self'"],
+            'X-Frame-Options'              => ['DENY'],
+            'X-Content-Type-Options'       => ['nosniff'],
+            'Referrer-Policy'              => ['strict-origin-when-cross-origin'],
+            'Permissions-Policy'           => ['camera=()'],
+            'Cross-Origin-Opener-Policy'   => ['same-origin'],
+            'Cross-Origin-Embedder-Policy' => ['require-corp'],
+            'Cross-Origin-Resource-Policy' => ['same-origin'],
+        ]);
+
+        $result = $this->analyzer->analyzeResponse($response);
+
+        $this->assertTrue($result->isClean());
+        $this->assertSame(0, $result->count());
+    }
+
+    #[Test]
+    public function testAnalyzeResponseWithoutHeadersReportsAllMissing(): void
+    {
+        $response = $this->responseWithHeaders([]);
+
+        $result = $this->analyzer->analyzeResponse($response);
+
+        $this->assertFalse($result->isClean());
+        $this->assertTrue($result->hasHighOrAbove());
+        $this->assertGreaterThanOrEqual(9, $result->count());
+    }
+
+    #[Test]
+    public function testAnalyzeResponseJoinsMultipleHeaderValues(): void
+    {
+        // Multiple values for one header must be joined with ", " (matching
+        // PSR-7 getHeaderLine semantics) before analysis. The invalid
+        // X-Content-Type-Options finding echoes the value, proving the join.
+        $response = $this->responseWithHeaders([
+            'X-Content-Type-Options' => ['foo', 'bar'],
+        ]);
+
+        $result   = $this->analyzer->analyzeResponse($response);
+        $findings = $result->forHeader('X-Content-Type-Options');
+
+        $this->assertCount(1, $findings);
+        $this->assertStringContainsString('"foo, bar"', $findings[0]->message);
+    }
+
     // === AnalysisResult ===
 
     #[Test]
@@ -520,6 +573,19 @@ final class SecurityHeaderAnalyzerTest extends TestCase
         $result = $this->analyzer->analyze($secureDefaults);
 
         return $result->forHeader($header);
+    }
+
+    /**
+     * Build a PSR-7 response stub exposing the given headers
+     *
+     * @param array<string, list<string>> $headers
+     */
+    private function responseWithHeaders(array $headers): ResponseInterface
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('getHeaders')->willReturn($headers);
+
+        return $response;
     }
 
     /**


### PR DESCRIPTION
## Summary

Adds `SecurityHeaderAnalyzer::analyzeResponse(ResponseInterface $response): AnalysisResult`, letting callers analyze a PSR-7 response directly instead of manually extracting an `array<string, string>` header map first. PSR-7 responses are the standard in middleware stacks.

The method extracts the response headers, joins multi-value headers with `", "` (matching PSR-7 `getHeaderLine` semantics), and delegates to the existing `analyze()`.

## Changes

- `SecurityHeaderAnalyzer::analyzeResponse()` — new public entry point
- `deptrac.yaml` — allow `HeadersAnalyzer` to depend on the `External` (PSR) layer
- `composer.json` — `suggest` entry for `psr/http-message`
- Tests — clean response, all-headers-missing, multi-value join

## Quality Gates

- PHPStan (L8), Psalm (L1), PHPMD, PHP-CS-Fixer, Rector, Deptrac (0 violations): pass
- PHPUnit: full suite green (3160 tests)
- Infection: runs in CI (pcov unavailable locally)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)