### PR TITLE
build(infection): bump config schema to installed 0.33.2

### DIFF
--- a/infection.json5
+++ b/infection.json5
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://raw.githubusercontent.com/infection/infection/0.29.0/resources/schema.json",
+    "$schema": "https://raw.githubusercontent.com/infection/infection/0.33.2/resources/schema.json",
     "source": {
         "directories": ["src"]
     },


### PR DESCRIPTION
## Summary

The `$schema` reference in `infection.json5` was pinned to `0.29.0`, which predates the `ReturnRemoval` mutator. IDEs that validate the file against that schema flagged the existing `ReturnRemoval` ignore block as an unknown property ("Property 'ReturnRemoval' is not allowed").

This bumps the schema reference to `0.33.2` — the installed Infection version, whose schema includes `ReturnRemoval` — resolving the false-positive warning. No mutator config or behavior changes.

## Verification

- `ReturnRemoval` confirmed present in the installed Infection 0.33.2 (`vendor/infection/infection/src/Mutator/Removal/ReturnRemoval.php`) and in its bundled `resources/schema.json`.
- Diff is a single line (the `$schema` URL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)