### PR TITLE
feat(csrf): add Double Submit Cookie CSRF middleware

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Limiting, SRI, and Audit Logging.
 | **RateLimiting** | Rate limiting with multiple algorithms            | `DefaultRateLimiter`, `RateLimitConfig`                            |
 | **SRI**          | Subresource Integrity hash generation             | `SriHashGenerator`, `IntegrityAttribute`                           |
 | **Analyzer**     | Security header analysis and auditing             | `SecurityHeaderAnalyzer`, `AnalysisResult`                         |
-| **Middleware**   | PSR-15 middleware for drop-in framework integration | `SecurityHeadersMiddleware`, `CsrfMiddleware`, `RateLimitMiddleware` |
+| **Middleware**   | PSR-15 middleware for drop-in framework integration | `SecurityHeadersMiddleware`, `CsrfMiddleware`, `DoubleSubmitCsrfMiddleware`, `RateLimitMiddleware` |
 | **Logging**      | Security event audit logging                      | `SecurityAuditLogger`, `SecurityEvent`                             |
 
 ## Requirements

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -448,6 +448,8 @@ deptrac:
       - CspNonce
       - CsrfMain
       - CsrfException
+      - CookieMain
+      - CookieException
       - RateLimitingMain
       - RateLimitingException
       - External

--- a/docs/middleware.md
+++ b/docs/middleware.md
@@ -88,6 +88,48 @@ $token = $request->getAttribute('csrf-token');
 echo "<input type=\"hidden\" name=\"_csrf_token\" value=\"{$token}\">";
 ```
 
+## Double Submit CSRF Middleware
+
+Stateless CSRF protection for SPA/API setups that cannot rely on server-side
+session storage. Uses the HMAC-signed Double Submit Cookie pattern: every
+response carries a JavaScript-readable cookie holding the raw token, while the
+matching signed token is exposed via request attribute `csrf-token`. On
+state-changing requests the cookie token is validated against the signed token
+from the header or body.
+
+```php
+use Zappzarapp\Security\Csrf\CsrfProtection;
+use Zappzarapp\Security\Middleware\DoubleSubmitCsrfMiddleware;
+
+$protection = CsrfProtection::doubleSubmit($secret); // secret: min 32 bytes
+$middleware = new DoubleSubmitCsrfMiddleware($protection);
+
+// In Slim:
+$app->add($middleware);
+```
+
+### Token Source Priority
+
+1. Request header (configured via `CsrfConfig::headerName`, default: `X-CSRF-Token`)
+2. Parsed body field (configured via `CsrfConfig::fieldName`, default: `_csrf_token`)
+
+### Using the Signed Token in a SPA
+
+```php
+// In a PSR-15 handler — hand the signed token to JavaScript:
+$signedToken = $request->getAttribute('csrf-token');
+echo "<meta name=\"csrf-token\" content=\"{$signedToken}\">";
+// JS reads the cookie + meta token and sends the signed value in X-CSRF-Token.
+```
+
+### Development Over HTTP
+
+The cookie sets the `Secure` flag by default. Disable it for local HTTP testing:
+
+```php
+$middleware = new DoubleSubmitCsrfMiddleware($protection, secure: false);
+```
+
 ## Rate Limit Middleware
 
 Enforces rate limits and returns 429 responses when exceeded. Rate limit headers

--- a/src/Middleware/DoubleSubmitCsrfMiddleware.php
+++ b/src/Middleware/DoubleSubmitCsrfMiddleware.php
@@ -1,0 +1,150 @@
+<?php
+
+/**
+ * @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive
+ * @noinspection PhpComposerExtensionStubsInspection psr/http-server-middleware is optional (suggest)
+ */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Middleware;
+
+use Override;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Random\RandomException;
+use Zappzarapp\Security\Cookie\CookieBuilder;
+use Zappzarapp\Security\Cookie\Exception\InvalidCookieNameException;
+use Zappzarapp\Security\Cookie\Exception\InvalidCookieValueException;
+use Zappzarapp\Security\Cookie\SameSitePolicy;
+use Zappzarapp\Security\Csrf\CsrfProtection;
+use Zappzarapp\Security\Csrf\Exception\CsrfTokenMismatchException;
+use Zappzarapp\Security\Csrf\Exception\InvalidCsrfTokenException;
+
+/**
+ * PSR-15 middleware for CSRF protection (HMAC-Signed Double Submit Cookie Pattern)
+ *
+ * Complements {@see CsrfMiddleware} (Synchronizer Token Pattern) for stateless
+ * SPA/API setups that cannot rely on server-side session storage.
+ *
+ * Every response carries a fresh CSRF cookie holding the raw token, while the
+ * matching HMAC-signed token is exposed via the request attribute 'csrf-token'
+ * for the application to embed in forms or hand to client-side JavaScript.
+ *
+ * Safe methods (GET, HEAD, OPTIONS) pass through. State-changing methods
+ * (POST, PUT, DELETE, PATCH) validate the cookie token against the signed
+ * token from the request header or parsed body field before the cookie is
+ * rotated.
+ *
+ * @throws CsrfTokenMismatchException When token validation fails
+ * @throws InvalidCsrfTokenException When token format is invalid
+ */
+final readonly class DoubleSubmitCsrfMiddleware implements MiddlewareInterface
+{
+    public const string TOKEN_ATTRIBUTE = 'csrf-token';
+
+    private const array SAFE_METHODS = ['GET', 'HEAD', 'OPTIONS'];
+
+    /**
+     * @param CsrfProtection $protection CSRF facade created via CsrfProtection::doubleSubmit()
+     * @param bool $secure Set the Secure cookie flag (keep true in production)
+     */
+    public function __construct(
+        private CsrfProtection $protection,
+        private bool $secure = true,
+    ) {
+    }
+
+    /**
+     * @throws CsrfTokenMismatchException
+     * @throws InvalidCsrfTokenException
+     * @throws InvalidCookieNameException
+     * @throws InvalidCookieValueException
+     * @throws RandomException
+     */
+    #[Override]
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
+    {
+        if (!in_array($request->getMethod(), self::SAFE_METHODS, true)) {
+            $this->validateTokens($request);
+        }
+
+        $token = $this->protection->token();
+
+        $request  = $request->withAttribute(self::TOKEN_ATTRIBUTE, $this->protection->signToken($token));
+        $response = $handler->handle($request);
+
+        return $this->withCsrfCookie($response, $token->value());
+    }
+
+    /**
+     * @throws CsrfTokenMismatchException
+     * @throws InvalidCsrfTokenException
+     */
+    private function validateTokens(ServerRequestInterface $request): void
+    {
+        $this->protection->validateDoubleSubmit(
+            $this->extractCookieToken($request),
+            $this->extractSubmittedToken($request),
+        );
+    }
+
+    /**
+     * @throws CsrfTokenMismatchException If the cookie token is absent
+     */
+    private function extractCookieToken(ServerRequestInterface $request): string
+    {
+        $cookies = $request->getCookieParams();
+        $name    = $this->protection->cookieName();
+
+        if (isset($cookies[$name]) && is_string($cookies[$name])) {
+            return $cookies[$name];
+        }
+
+        throw CsrfTokenMismatchException::missingToken();
+    }
+
+    /**
+     * @throws CsrfTokenMismatchException If neither header nor body carries a token
+     */
+    private function extractSubmittedToken(ServerRequestInterface $request): string
+    {
+        $header = $request->getHeaderLine($this->protection->headerName());
+
+        if ($header !== '') {
+            return $header;
+        }
+
+        $fieldName = $this->protection->fieldName();
+        $body      = $request->getParsedBody();
+
+        if (is_array($body) && isset($body[$fieldName]) && is_string($body[$fieldName])) {
+            return $body[$fieldName];
+        }
+
+        throw CsrfTokenMismatchException::missingToken();
+    }
+
+    /**
+     * Attach the raw token as a JavaScript-readable cookie on the response
+     *
+     * @throws InvalidCookieNameException If the configured cookie name is invalid
+     * @throws InvalidCookieValueException If the token value is invalid
+     */
+    private function withCsrfCookie(ResponseInterface $response, string $rawToken): ResponseInterface
+    {
+        $options = $this->protection->cookieOptions($this->secure);
+
+        $cookie = CookieBuilder::create($options['name'], $rawToken)
+            ->expires($options['expires'])
+            ->path($options['path'])
+            ->secure($options['secure'])
+            ->httpOnly($options['httponly'])
+            ->sameSite(SameSitePolicy::from($options['samesite']))
+            ->build();
+
+        return $response->withAddedHeader('Set-Cookie', $cookie->headerValue());
+    }
+}

--- a/tests/Middleware/DoubleSubmitCsrfMiddlewareTest.php
+++ b/tests/Middleware/DoubleSubmitCsrfMiddlewareTest.php
@@ -1,0 +1,377 @@
+<?php
+
+/** @noinspection PhpUnhandledExceptionInspection Tests may throw RandomException */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\Attributes\UsesClass;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+use Random\RandomException;
+use Zappzarapp\Security\Cookie\CookieBuilder;
+use Zappzarapp\Security\Cookie\CookieOptions;
+use Zappzarapp\Security\Cookie\CookieValidator;
+use Zappzarapp\Security\Cookie\SameSitePolicy;
+use Zappzarapp\Security\Cookie\SecureCookie;
+use Zappzarapp\Security\Csrf\CsrfConfig;
+use Zappzarapp\Security\Csrf\CsrfProtection;
+use Zappzarapp\Security\Csrf\Exception\CsrfTokenMismatchException;
+use Zappzarapp\Security\Csrf\Pattern\DoubleSubmitCookiePattern;
+use Zappzarapp\Security\Csrf\Token\CsrfToken;
+use Zappzarapp\Security\Csrf\Token\CsrfTokenGenerator;
+use Zappzarapp\Security\Middleware\DoubleSubmitCsrfMiddleware;
+
+#[CoversClass(DoubleSubmitCsrfMiddleware::class)]
+#[UsesClass(CsrfProtection::class)]
+#[UsesClass(CsrfConfig::class)]
+#[UsesClass(DoubleSubmitCookiePattern::class)]
+#[UsesClass(CsrfToken::class)]
+#[UsesClass(CsrfTokenGenerator::class)]
+#[UsesClass(CsrfTokenMismatchException::class)]
+#[UsesClass(CookieBuilder::class)]
+#[UsesClass(CookieOptions::class)]
+#[UsesClass(CookieValidator::class)]
+#[UsesClass(SecureCookie::class)]
+#[UsesClass(SameSitePolicy::class)]
+final class DoubleSubmitCsrfMiddlewareTest extends TestCase
+{
+    private const string SECRET = 'this-is-a-32-byte-test-secret!!!';
+
+    private CsrfProtection $protection;
+
+    private DoubleSubmitCsrfMiddleware $middleware;
+
+    protected function setUp(): void
+    {
+        $this->protection = CsrfProtection::doubleSubmit(self::SECRET);
+        $this->middleware = new DoubleSubmitCsrfMiddleware($this->protection);
+    }
+
+    #[Test]
+    public function testSafeRequestPassesThrough(): void
+    {
+        $request  = $this->createRequest('GET');
+        $response = $this->createResponse();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testHeadAndOptionsPassThrough(): void
+    {
+        foreach (['HEAD', 'OPTIONS'] as $method) {
+            $request  = $this->createRequest($method);
+            $response = $this->createResponse();
+
+            $handler = $this->createStub(RequestHandlerInterface::class);
+            $handler->method('handle')->willReturn($response);
+
+            $this->assertSame($response, $this->middleware->process($request, $handler));
+        }
+    }
+
+    #[Test]
+    public function testExposesSignedTokenInRequestAttribute(): void
+    {
+        $request  = $this->createRequest('GET');
+        $response = $this->createResponse();
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($response);
+
+        $storedToken = null;
+
+        $request->method('withAttribute')
+            ->willReturnCallback(function (string $name, mixed $value) use (&$storedToken, $request): ServerRequestInterface {
+                if ($name === DoubleSubmitCsrfMiddleware::TOKEN_ATTRIBUTE) {
+                    $storedToken = $value;
+                }
+
+                return $request;
+            });
+
+        $this->middleware->process($request, $handler);
+
+        $this->assertIsString($storedToken);
+        // Signed token has the "token.signature" shape
+        $this->assertStringContainsString('.', $storedToken);
+    }
+
+    #[Test]
+    public function testResponseCarriesReadableCsrfCookie(): void
+    {
+        $setCookie = '';
+
+        $request = $this->createRequest('GET');
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse($setCookie));
+
+        $this->middleware->process($request, $handler);
+
+        $this->assertNotSame('', $setCookie);
+        $this->assertStringStartsWith($this->protection->cookieName() . '=', $setCookie);
+        $this->assertStringContainsString('SameSite=Strict', $setCookie);
+        $this->assertStringContainsString('Secure', $setCookie);
+        // Double-submit cookie must be readable by JavaScript
+        $this->assertStringNotContainsString('HttpOnly', $setCookie);
+    }
+
+    #[Test]
+    public function testEmittedCookieAndAttributeFormValidPair(): void
+    {
+        $setCookie   = '';
+        $signedToken = null;
+
+        $request = $this->createRequest('GET');
+        $request->method('withAttribute')
+            ->willReturnCallback(function (string $name, mixed $value) use (&$signedToken, $request): ServerRequestInterface {
+                if ($name === DoubleSubmitCsrfMiddleware::TOKEN_ATTRIBUTE) {
+                    $signedToken = $value;
+                }
+
+                return $request;
+            });
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse($setCookie));
+
+        $this->middleware->process($request, $handler);
+
+        $this->assertNotSame('', $setCookie);
+        $this->assertIsString($signedToken);
+
+        $cookieToken = $this->cookieValue($setCookie);
+
+        // The pair emitted on a safe request must validate on the next request
+        $this->assertTrue($this->protection->isValidDoubleSubmit($cookieToken, $signedToken));
+    }
+
+    #[Test]
+    public function testInsecureFlagOmitsSecureAttribute(): void
+    {
+        $middleware = new DoubleSubmitCsrfMiddleware($this->protection, secure: false);
+
+        $setCookie = '';
+        $request   = $this->createRequest('GET');
+        $handler   = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse($setCookie));
+
+        $middleware->process($request, $handler);
+
+        $this->assertNotSame('', $setCookie);
+        $this->assertStringNotContainsString('Secure', $setCookie);
+    }
+
+    #[Test]
+    public function testPostValidatesCookieAgainstHeaderToken(): void
+    {
+        [$cookie, $signed] = $this->validPair();
+
+        $request  = $this->createRequest('POST', cookieToken: $cookie, headerToken: $signed);
+        $response = $this->createResponse();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostValidatesCookieAgainstBodyToken(): void
+    {
+        [$cookie, $signed] = $this->validPair();
+
+        $request  = $this->createRequest('POST', cookieToken: $cookie, bodyToken: $signed);
+        $response = $this->createResponse();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testHeaderTokenTakesPriorityOverBody(): void
+    {
+        [$cookie, $signed] = $this->validPair();
+
+        $request  = $this->createRequest('POST', cookieToken: $cookie, headerToken: $signed, bodyToken: 'wrong.signature');
+        $response = $this->createResponse();
+
+        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler->expects($this->once())->method('handle')->willReturn($response);
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostThrowsOnMissingCookieToken(): void
+    {
+        [, $signed] = $this->validPair();
+
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request = $this->createRequest('POST', headerToken: $signed);
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse());
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostThrowsWhenCookieTokenIsNotAString(): void
+    {
+        [, $signed] = $this->validPair();
+
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('POST');
+        $request->method('getCookieParams')->willReturn([$this->protection->cookieName() => ['array-not-string']]);
+        $request->method('getHeaderLine')->willReturn($signed);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse());
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostThrowsOnMissingSubmittedToken(): void
+    {
+        [$cookie] = $this->validPair();
+
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request = $this->createRequest('POST', cookieToken: $cookie);
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse());
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostThrowsWhenBodyTokenIsNotAString(): void
+    {
+        [$cookie] = $this->validPair();
+
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn('POST');
+        $request->method('getCookieParams')->willReturn([$this->protection->cookieName() => $cookie]);
+        $request->method('getHeaderLine')->willReturn('');
+        $request->method('getParsedBody')->willReturn([$this->protection->fieldName() => ['not-a-string']]);
+
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse());
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPostThrowsOnTokenMismatch(): void
+    {
+        [$cookie] = $this->validPair();
+
+        $this->expectException(CsrfTokenMismatchException::class);
+
+        $request = $this->createRequest('POST', cookieToken: $cookie, headerToken: 'tampered.signature');
+        $handler = $this->createStub(RequestHandlerInterface::class);
+        $handler->method('handle')->willReturn($this->createResponse());
+
+        $this->middleware->process($request, $handler);
+    }
+
+    #[Test]
+    public function testPutAndDeleteRequireValidation(): void
+    {
+        foreach (['PUT', 'DELETE'] as $method) {
+            [$cookie, $signed] = $this->validPair();
+
+            $request  = $this->createRequest($method, cookieToken: $cookie, headerToken: $signed);
+            $response = $this->createResponse();
+
+            $handler = $this->createMock(RequestHandlerInterface::class);
+            $handler->expects($this->once())->method('handle')->willReturn($response);
+
+            $this->middleware->process($request, $handler);
+        }
+    }
+
+    /**
+     * Produce a matching (raw cookie token, signed token) pair
+     *
+     * @return array{string, string}
+     *
+     * @throws RandomException If no suitable random source is available
+     */
+    private function validPair(): array
+    {
+        $token = $this->protection->token();
+
+        return [$token->value(), $this->protection->signToken($token)];
+    }
+
+    /**
+     * Extract the cookie value from a Set-Cookie header string
+     */
+    private function cookieValue(string $setCookie): string
+    {
+        $first = explode(';', $setCookie, 2)[0];
+        $value = explode('=', $first, 2)[1];
+
+        return rawurldecode($value);
+    }
+
+    private function createRequest(
+        string $method,
+        ?string $cookieToken = null,
+        ?string $headerToken = null,
+        ?string $bodyToken = null,
+    ): ServerRequestInterface&Stub {
+        $request = $this->createStub(ServerRequestInterface::class);
+        $request->method('getMethod')->willReturn($method);
+        $request->method('withAttribute')->willReturn($request);
+        $request->method('getCookieParams')->willReturn(
+            $cookieToken !== null ? [$this->protection->cookieName() => $cookieToken] : [],
+        );
+        $request->method('getHeaderLine')
+            ->willReturnCallback(fn (string $name): string => $name === $this->protection->headerName() && $headerToken !== null
+                ? $headerToken
+                : '');
+        $request->method('getParsedBody')->willReturn(
+            $bodyToken !== null ? [$this->protection->fieldName() => $bodyToken] : [],
+        );
+
+        return $request;
+    }
+
+    /**
+     * Build a response stub that captures the Set-Cookie header it receives
+     */
+    private function createResponse(string &$setCookie = ''): ResponseInterface&Stub
+    {
+        $response = $this->createStub(ResponseInterface::class);
+        $response->method('withAddedHeader')
+            ->willReturnCallback(function (string $name, mixed $value) use (&$setCookie, $response): ResponseInterface {
+                if ($name === 'Set-Cookie' && is_string($value)) {
+                    $setCookie = $value;
+                }
+
+                return $response;
+            });
+
+        return $response;
+    }
+}


### PR DESCRIPTION
## Summary

Adds `DoubleSubmitCsrfMiddleware`, a PSR-15 middleware variant for the HMAC-signed Double Submit Cookie pattern, complementing the existing Synchronizer Token `CsrfMiddleware`. Targets stateless SPA/API setups that cannot rely on server-side session storage.

- Every response carries a JavaScript-readable cookie holding the raw token; the matching HMAC-signed token is exposed via the request attribute `csrf-token`.
- State-changing requests (POST, PUT, DELETE, PATCH) validate the cookie token against the signed header/body token via `CsrfProtection::validateDoubleSubmit()` **before** the cookie is rotated.
- Safe methods (GET, HEAD, OPTIONS) pass through.
- Optional `secure: false` constructor flag for local HTTP development.

## Changes

- `src/Middleware/DoubleSubmitCsrfMiddleware.php` — new middleware
- `deptrac.yaml` — allow the Middleware layer to depend on the Cookie layers for `Set-Cookie` construction
- `README.md`, `docs/middleware.md` — documentation
- Tests — 15 cases (passthrough, cookie flags/Secure, valid-pair round-trip, header-over-body priority, missing/non-string cookie & submitted tokens, mismatch, PUT/DELETE)

## Quality Gates

- PHPUnit (full suite), PHPStan L8, Psalm L1, PHPMD, Deptrac (0 violations), CS-Fixer, Rector: pass
- Infection: runs in CI (`in_array(..., true)` idiom matches existing `CsrfMiddleware`, 100% MSI without ignores)
- Security review: no findings

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)