### PR TITLE
feat(csrf): add Redis and PDO CSRF storage backends

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -41,10 +41,10 @@
     "psr/http-message": "For PSR-7 response analysis in SecurityHeaderAnalyzer",
     "psr/http-client": "For PSR-18 HTTP client support in PwnedPasswordChecker",
     "psr/http-factory": "For PSR-17 HTTP factory support in PwnedPasswordChecker",
-    "ext-redis": "For Redis rate limit storage (phpredis extension)",
-    "predis/predis": "For Redis rate limit storage (pure PHP client)",
+    "ext-redis": "For Redis rate limit and CSRF token storage (phpredis extension)",
+    "predis/predis": "For Redis rate limit and CSRF token storage (pure PHP client)",
     "ext-memcached": "For Memcached rate limit storage",
-    "ext-pdo": "For PDO rate limit storage (MySQL, PostgreSQL, SQLite)",
+    "ext-pdo": "For PDO rate limit and CSRF token storage (MySQL, PostgreSQL, SQLite)",
     "psr/http-server-middleware": "For PSR-15 middleware support",
     "psr/http-server-handler": "For PSR-15 middleware support"
   },

--- a/deptrac.yaml
+++ b/deptrac.yaml
@@ -357,7 +357,8 @@ deptrac:
 
     # CSRF Module Rules
     CsrfException: ~
-    CsrfStorage: ~
+    CsrfStorage:
+      - CsrfException
     CsrfToken:
       - CsrfException
     CsrfValidation:

--- a/docs/csrf.md
+++ b/docs/csrf.md
@@ -23,14 +23,16 @@ if (!$csrf->validateToken($_POST['_csrf'])) {
 
 ## Classes
 
-| Class                       | Description                       |
-| --------------------------- | --------------------------------- |
-| `CsrfProtection`            | Main CSRF protection handler      |
-| `SynchronizerTokenPattern`  | Server-side token storage pattern |
-| `DoubleSubmitCookiePattern` | Stateless cookie-based pattern    |
-| `SessionCsrfStorage`        | Store tokens in PHP session       |
-| `ArrayCsrfStorage`          | In-memory storage (for testing)   |
-| `CsrfToken`                 | Token value object                |
+| Class                       | Description                         |
+| --------------------------- | ----------------------------------- |
+| `CsrfProtection`            | Main CSRF protection handler        |
+| `SynchronizerTokenPattern`  | Server-side token storage pattern   |
+| `DoubleSubmitCookiePattern` | Stateless cookie-based pattern      |
+| `SessionCsrfStorage`        | Store tokens in PHP session         |
+| `RedisCsrfStorage`          | Store tokens in Redis (distributed) |
+| `PdoCsrfStorage`            | Store tokens in a SQL database      |
+| `ArrayCsrfStorage`          | In-memory storage (for testing)     |
+| `CsrfToken`                 | Token value object                  |
 
 ## Patterns
 
@@ -103,29 +105,59 @@ use Zappzarapp\Security\Csrf\Storage\SessionCsrfStorage;
 $storage = new SessionCsrfStorage();
 ```
 
+### Redis Storage
+
+Distributed storage backed by Redis. Works with the phpredis extension or the
+Predis client. A non-null TTL maps to a Redis key expiry; a null TTL stores the
+token without expiry.
+
+```php
+use Zappzarapp\Security\Csrf\Storage\RedisCsrfStorage;
+
+$storage = new RedisCsrfStorage($redis);            // default prefix "csrf:"
+$storage = new RedisCsrfStorage($redis, 'myapp:');  // custom key prefix
+```
+
+> **Note:** `clear()` enumerates keys with the Redis `KEYS` command, which scans
+> the whole keyspace. Treat it as a maintenance operation, not a hot-path call.
+
+### PDO Storage
+
+Database-backed storage for MySQL, PostgreSQL, or SQLite. Create the table from
+the bundled schema for your driver:
+
+```php
+use Zappzarapp\Security\Csrf\Storage\PdoCsrfStorage;
+
+$pdo->exec(sprintf(PdoCsrfStorage::SCHEMA['sqlite'], 'csrf_tokens', 'csrf_tokens', 'csrf_tokens'));
+
+$storage = new PdoCsrfStorage($pdo);                       // default table "csrf_tokens", prefix "csrf:"
+$storage = new PdoCsrfStorage($pdo, 'tokens', 'myapp:');   // custom table and prefix
+
+// Periodically purge expired tokens (e.g. via cron):
+$storage->cleanup();
+```
+
+The PDO connection must use `PDO::ERRMODE_EXCEPTION`.
+
 ### Custom Storage
 
-Implement `CsrfStorageInterface` for custom backends (Redis, database, etc.).
+Implement `CsrfStorageInterface` for other backends.
 
 ```php
 use Zappzarapp\Security\Csrf\Storage\CsrfStorageInterface;
 
-class RedisCsrfStorage implements CsrfStorageInterface
+final class MyCustomCsrfStorage implements CsrfStorageInterface
 {
-    public function store(string $tokenId, string $token, int $ttl): void
-    {
-        // Store in Redis
-    }
+    public function store(string $key, string $token, ?int $ttl = null): void { /* ... */ }
 
-    public function retrieve(string $tokenId): ?string
-    {
-        // Retrieve from Redis
-    }
+    public function retrieve(string $key): ?string { /* ... */ }
 
-    public function remove(string $tokenId): void
-    {
-        // Remove from Redis
-    }
+    public function remove(string $key): void { /* ... */ }
+
+    public function has(string $key): bool { /* ... */ }
+
+    public function clear(): void { /* ... */ }
 }
 ```
 

--- a/infection.json5
+++ b/infection.json5
@@ -161,7 +161,8 @@
                 "Zappzarapp\\Security\\RateLimiting\\Algorithm\\*",
                 "Zappzarapp\\Security\\RateLimiting\\RateLimitResult::*",
                 // MySQL-specific SQL in upsert() — untestable without MySQL
-                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::upsert"
+                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::upsert",
+                "Zappzarapp\\Security\\Csrf\\Storage\\PdoCsrfStorage::upsert"
             ]
         },
         "ConcatOperandRemoval": {
@@ -187,7 +188,8 @@
                 // Truncation marker "..." cosmetic
                 "Zappzarapp\\Security\\Logging\\SecurityAuditLogger::truncateContext",
                 // MySQL-specific SQL in upsert() — untestable without MySQL
-                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::upsert"
+                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::upsert",
+                "Zappzarapp\\Security\\Csrf\\Storage\\PdoCsrfStorage::upsert"
             ]
         },
         "UnwrapArraySlice": {
@@ -548,6 +550,7 @@
             "ignore": [
                 // PDO getAttribute returns string anyway, cast is defensive
                 "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::__construct",
+                "Zappzarapp\\Security\\Csrf\\Storage\\PdoCsrfStorage::__construct",
                 // PDO binds parameters as strings regardless of explicit cast
                 "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::increment",
                 // EQUIVALENT: PSR-7 getHeaders() keys are always header-name strings;
@@ -563,7 +566,8 @@
                 // URL attribute detection - defense in depth for various element types
                 "Zappzarapp\\Security\\Sanitization\\Html\\HtmlSanitizer::isUrlAttribute",
                 // MySQL match arm in upsert() — untestable without MySQL
-                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::upsert"
+                "Zappzarapp\\Security\\RateLimiting\\Storage\\PdoStorage::upsert",
+                "Zappzarapp\\Security\\Csrf\\Storage\\PdoCsrfStorage::upsert"
             ]
         },
 

--- a/src/Csrf/Exception/CsrfStorageException.php
+++ b/src/Csrf/Exception/CsrfStorageException.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Csrf\Exception;
+
+use RuntimeException;
+
+/**
+ * Exception thrown when CSRF token storage fails
+ */
+final class CsrfStorageException extends RuntimeException
+{
+    /**
+     * Create for read failure
+     */
+    public static function readFailed(string $key, string $reason): self
+    {
+        return new self(sprintf('Failed to read CSRF token for "%s": %s', $key, $reason));
+    }
+
+    /**
+     * Create for write failure
+     */
+    public static function writeFailed(string $key, string $reason): self
+    {
+        return new self(sprintf('Failed to write CSRF token for "%s": %s', $key, $reason));
+    }
+}

--- a/src/Csrf/Storage/PdoCsrfStorage.php
+++ b/src/Csrf/Storage/PdoCsrfStorage.php
@@ -1,0 +1,199 @@
+<?php
+
+/**
+ * @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive
+ * @noinspection PhpComposerExtensionStubsInspection ext-pdo is optional (suggest), class only used when available
+ */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Csrf\Storage;
+
+use Override;
+use PDO;
+use PDOException;
+use Zappzarapp\Security\Csrf\Exception\CsrfStorageException;
+
+/**
+ * PDO-based CSRF token storage
+ *
+ * Supports MySQL, PostgreSQL, and SQLite. Enables distributed CSRF protection
+ * backed by a relational database where Redis is not available.
+ *
+ * Tokens are stored under a configurable key prefix. A non-null TTL stores an
+ * absolute expiry timestamp; a null TTL stores no expiry ("session lifetime"
+ * semantics) by leaving expires_at NULL.
+ */
+final readonly class PdoCsrfStorage implements CsrfStorageInterface
+{
+    /**
+     * Table schemas per database driver.
+     *
+     * Use with sprintf() to inject your table name:
+     *   $pdo->exec(sprintf(PdoCsrfStorage::SCHEMA['sqlite'], 'csrf_tokens', 'csrf_tokens', 'csrf_tokens'));
+     *
+     * @var array<string, string>
+     */
+    public const array SCHEMA = [
+        'mysql' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS %s (
+                `key` VARCHAR(255) NOT NULL PRIMARY KEY,
+                `token` TEXT NOT NULL,
+                `expires_at` INT UNSIGNED NULL,
+                INDEX idx_expires_at (`expires_at`)
+            ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4
+            SQL,
+        'pgsql' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS %s (
+                "key" VARCHAR(255) NOT NULL PRIMARY KEY,
+                "token" TEXT NOT NULL,
+                "expires_at" INTEGER NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_%s_expires_at ON %s ("expires_at")
+            SQL,
+        'sqlite' => <<<'SQL'
+            CREATE TABLE IF NOT EXISTS %s (
+                "key" TEXT NOT NULL PRIMARY KEY,
+                "token" TEXT NOT NULL,
+                "expires_at" INTEGER NULL
+            );
+            CREATE INDEX IF NOT EXISTS idx_%s_expires_at ON %s ("expires_at")
+            SQL,
+    ];
+
+    private string $driver;
+
+    /**
+     * @param PDO $pdo PDO connection instance (must have ERRMODE_EXCEPTION)
+     * @param string $table Table name for CSRF token data
+     * @param string $prefix Key prefix for namespacing
+     */
+    public function __construct(
+        private PDO $pdo,
+        private string $table = 'csrf_tokens',
+        private string $prefix = 'csrf:',
+    ) {
+        $this->driver = (string) $this->pdo->getAttribute(PDO::ATTR_DRIVER_NAME);
+    }
+
+    #[Override]
+    public function store(string $key, string $token, ?int $ttl = null): void
+    {
+        $prefixedKey = $this->prefix . $key;
+        $expiresAt   = $ttl !== null ? time() + $ttl : null;
+
+        try {
+            $this->upsert($prefixedKey, $token, $expiresAt);
+        } catch (PDOException $pdoException) {
+            throw CsrfStorageException::writeFailed($key, $pdoException->getMessage());
+        }
+    }
+
+    #[Override]
+    public function retrieve(string $key): ?string
+    {
+        $prefixedKey = $this->prefix . $key;
+
+        try {
+            $stmt = $this->pdo->prepare(
+                sprintf('SELECT "token", "expires_at" FROM %s WHERE "key" = ?', $this->table),
+            );
+            $stmt->execute([$prefixedKey]);
+
+            /** @var array{token: string, expires_at: int|null}|false $row */
+            $row = $stmt->fetch(PDO::FETCH_ASSOC);
+        } catch (PDOException $pdoException) {
+            throw CsrfStorageException::readFailed($key, $pdoException->getMessage());
+        }
+
+        if ($row === false) {
+            return null;
+        }
+
+        if ($row['expires_at'] !== null && $row['expires_at'] <= time()) {
+            $this->remove($key);
+
+            return null;
+        }
+
+        return $row['token'];
+    }
+
+    #[Override]
+    public function remove(string $key): void
+    {
+        $prefixedKey = $this->prefix . $key;
+
+        try {
+            $stmt = $this->pdo->prepare(
+                sprintf('DELETE FROM %s WHERE "key" = ?', $this->table),
+            );
+            $stmt->execute([$prefixedKey]);
+        } catch (PDOException $pdoException) {
+            throw CsrfStorageException::writeFailed($key, $pdoException->getMessage());
+        }
+    }
+
+    #[Override]
+    public function has(string $key): bool
+    {
+        return $this->retrieve($key) !== null;
+    }
+
+    #[Override]
+    public function clear(): void
+    {
+        try {
+            $stmt = $this->pdo->prepare(
+                sprintf('DELETE FROM %s WHERE "key" LIKE ?', $this->table),
+            );
+            $stmt->execute([$this->prefix . '%']);
+        } catch (PDOException $pdoException) {
+            throw CsrfStorageException::writeFailed('*', $pdoException->getMessage());
+        }
+    }
+
+    /**
+     * Remove all expired entries
+     *
+     * Call periodically via cron to prevent table growth. Tokens stored without
+     * a TTL (expires_at IS NULL) are never removed by this method.
+     *
+     * @return int Number of deleted rows
+     */
+    public function cleanup(): int
+    {
+        try {
+            $stmt = $this->pdo->prepare(
+                sprintf('DELETE FROM %s WHERE "expires_at" IS NOT NULL AND "expires_at" <= ?', $this->table),
+            );
+            $stmt->execute([time()]);
+
+            return $stmt->rowCount();
+        } catch (PDOException $pdoException) {
+            throw CsrfStorageException::writeFailed('*', $pdoException->getMessage());
+        }
+    }
+
+    /**
+     * @throws PDOException
+     */
+    private function upsert(string $prefixedKey, string $token, ?int $expiresAt): void
+    {
+        $sql = match ($this->driver) {
+            'mysql' => sprintf(
+                'INSERT INTO %s (`key`, `token`, `expires_at`) VALUES (?, ?, ?)'
+                . ' ON DUPLICATE KEY UPDATE `token` = VALUES(`token`), `expires_at` = VALUES(`expires_at`)',
+                $this->table,
+            ),
+            default => sprintf(
+                'INSERT INTO %s ("key", "token", "expires_at") VALUES (?, ?, ?)'
+                . ' ON CONFLICT ("key") DO UPDATE SET "token" = EXCLUDED."token", "expires_at" = EXCLUDED."expires_at"',
+                $this->table,
+            ),
+        };
+
+        $stmt = $this->pdo->prepare($sql);
+        $stmt->execute([$prefixedKey, $token, $expiresAt]);
+    }
+}

--- a/src/Csrf/Storage/RedisCsrfStorage.php
+++ b/src/Csrf/Storage/RedisCsrfStorage.php
@@ -1,0 +1,97 @@
+<?php
+
+/** @noinspection PhpMultipleClassDeclarationsInspection Native PHP 8.3 attribute, stubs cause false positive */
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Csrf\Storage;
+
+use Override;
+
+/**
+ * Redis-based CSRF token storage
+ *
+ * Supports both phpredis extension (Redis class) and Predis client via duck
+ * typing. Enables distributed/stateless CSRF protection where tokens must be
+ * shared across application instances.
+ *
+ * Tokens are stored under a configurable key prefix. A non-null TTL maps to a
+ * Redis key expiry; a null TTL stores the token without expiry ("session
+ * lifetime" semantics).
+ *
+ * @psalm-suppress MixedReturnStatement
+ * @psalm-suppress MixedAssignment
+ * @psalm-suppress MixedMethodCall
+ * @psalm-suppress MixedArgument
+ */
+final readonly class RedisCsrfStorage implements CsrfStorageInterface
+{
+    /**
+     * @param object $client Redis or Predis\Client instance with get/set/setex/del/keys methods
+     * @param string $prefix Key prefix for namespacing
+     */
+    public function __construct(
+        private object $client,
+        private string $prefix = 'csrf:',
+    ) {
+    }
+
+    #[Override]
+    public function store(string $key, string $token, ?int $ttl = null): void
+    {
+        $prefixedKey = $this->prefix . $key;
+
+        if ($ttl !== null && $ttl > 0) {
+            /** @phpstan-ignore method.notFound (Redis/Predis duck typing) */
+            $this->client->setex($prefixedKey, $ttl, $token);
+
+            return;
+        }
+
+        /** @phpstan-ignore method.notFound (Redis/Predis duck typing) */
+        $this->client->set($prefixedKey, $token);
+    }
+
+    #[Override]
+    public function retrieve(string $key): ?string
+    {
+        /** @phpstan-ignore method.notFound (Redis/Predis duck typing) */
+        $data = $this->client->get($this->prefix . $key);
+
+        return is_string($data) ? $data : null;
+    }
+
+    #[Override]
+    public function remove(string $key): void
+    {
+        /** @phpstan-ignore method.notFound (Redis/Predis duck typing) */
+        $this->client->del($this->prefix . $key);
+    }
+
+    #[Override]
+    public function has(string $key): bool
+    {
+        return $this->retrieve($key) !== null;
+    }
+
+    /**
+     * Remove every token stored under the configured prefix
+     *
+     * Uses the KEYS command to enumerate matching keys. KEYS scans the whole
+     * keyspace and should be treated as a maintenance operation, not part of a
+     * hot request path.
+     */
+    #[Override]
+    public function clear(): void
+    {
+        /** @var list<string> $keys */
+        $keys = $this->client->keys($this->prefix . '*'); // @phpstan-ignore method.notFound
+
+        if ($keys === []) {
+            return;
+        }
+
+        /** @phpstan-ignore method.notFound (Redis/Predis duck typing) */
+        $this->client->del($keys);
+    }
+}

--- a/tests/Csrf/Storage/PdoCsrfStorageTest.php
+++ b/tests/Csrf/Storage/PdoCsrfStorageTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Csrf\Storage;
+
+use PDO;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\RequiresPhpExtension;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Zappzarapp\Security\Csrf\Exception\CsrfStorageException;
+use Zappzarapp\Security\Csrf\Storage\PdoCsrfStorage;
+
+#[CoversClass(PdoCsrfStorage::class)]
+#[RequiresPhpExtension('pdo_sqlite')]
+final class PdoCsrfStorageTest extends TestCase
+{
+    private PDO $pdo;
+
+    private PdoCsrfStorage $storage;
+
+    protected function setUp(): void
+    {
+        $this->pdo = new PDO('sqlite::memory:', null, null, [
+            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
+        ]);
+
+        $this->pdo->exec(sprintf(PdoCsrfStorage::SCHEMA['sqlite'], 'csrf_tokens', 'csrf_tokens', 'csrf_tokens'));
+
+        $this->storage = new PdoCsrfStorage($this->pdo);
+    }
+
+    #[Test]
+    public function testRetrieveReturnsNullForMissingKey(): void
+    {
+        $this->assertNull($this->storage->retrieve('nonexistent'));
+    }
+
+    #[Test]
+    public function testStoreAndRetrieve(): void
+    {
+        $this->storage->store('session1', 'token-value', 3600);
+
+        $this->assertSame('token-value', $this->storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testStoreWithoutTtlNeverExpires(): void
+    {
+        $this->storage->store('session1', 'token-value');
+
+        $this->assertSame('token-value', $this->storage->retrieve('session1'));
+        $this->assertSame(0, $this->storage->cleanup());
+        $this->assertSame('token-value', $this->storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testStoreWithElapsedTtlExpiresImmediately(): void
+    {
+        // A negative TTL produces a past expiry, exercising store()'s expiry
+        // binding without waiting for real time to pass.
+        $this->storage->store('session1', 'token-value', -1);
+
+        $this->assertNull($this->storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testStoreOverwritesExistingToken(): void
+    {
+        $this->storage->store('session1', 'token-one', 3600);
+        $this->storage->store('session1', 'token-two', 3600);
+
+        $this->assertSame('token-two', $this->storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testRetrieveReturnsNullForExpiredToken(): void
+    {
+        $this->insertRawToken('csrf:expired', 'old-token', time() - 1);
+
+        $this->assertNull($this->storage->retrieve('expired'));
+    }
+
+    #[Test]
+    public function testExpiredTokenIsDeletedOnRetrieve(): void
+    {
+        $this->insertRawToken('csrf:expired', 'old-token', time() - 1);
+
+        $this->storage->retrieve('expired');
+
+        $this->assertSame(0, $this->countRows());
+    }
+
+    #[Test]
+    public function testTokenAtExpiryBoundaryIsExpired(): void
+    {
+        $this->insertRawToken('csrf:boundary', 'token', time());
+
+        $this->assertNull($this->storage->retrieve('boundary'));
+    }
+
+    #[Test]
+    public function testRemoveDeletesToken(): void
+    {
+        $this->storage->store('session1', 'token-value', 3600);
+        $this->storage->remove('session1');
+
+        $this->assertNull($this->storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testHasReturnsTrueForStoredToken(): void
+    {
+        $this->storage->store('session1', 'token-value', 3600);
+
+        $this->assertTrue($this->storage->has('session1'));
+    }
+
+    #[Test]
+    public function testHasReturnsFalseForMissingToken(): void
+    {
+        $this->assertFalse($this->storage->has('session1'));
+    }
+
+    #[Test]
+    public function testClearRemovesAllPrefixedTokens(): void
+    {
+        $this->storage->store('session1', 'token-one', 3600);
+        $this->storage->store('session2', 'token-two', 3600);
+
+        $this->storage->clear();
+
+        $this->assertNull($this->storage->retrieve('session1'));
+        $this->assertNull($this->storage->retrieve('session2'));
+        $this->assertSame(0, $this->countRows());
+    }
+
+    #[Test]
+    public function testClearOnlyRemovesOwnPrefix(): void
+    {
+        $this->storage->store('session1', 'token-one', 3600);
+        $this->insertRawToken('other:session2', 'token-two', time() + 3600);
+
+        $this->storage->clear();
+
+        $this->assertSame(1, $this->countRows());
+    }
+
+    #[Test]
+    public function testCleanupRemovesExpiredKeepsValid(): void
+    {
+        $this->insertRawToken('csrf:expired1', 'token', time() - 1);
+        $this->insertRawToken('csrf:expired2', 'token', time() - 1);
+        $this->storage->store('valid', 'token-value', 3600);
+
+        $deleted = $this->storage->cleanup();
+
+        $this->assertSame(2, $deleted);
+        $this->assertSame('token-value', $this->storage->retrieve('valid'));
+    }
+
+    #[Test]
+    public function testUsesCustomTableName(): void
+    {
+        $this->pdo->exec(sprintf(PdoCsrfStorage::SCHEMA['sqlite'], 'custom_tokens', 'custom_tokens', 'custom_tokens'));
+
+        $storage = new PdoCsrfStorage($this->pdo, 'custom_tokens');
+        $storage->store('session1', 'token-value', 3600);
+
+        $this->assertSame('token-value', $storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testReadFailureThrowsStorageException(): void
+    {
+        $this->pdo->exec('DROP TABLE csrf_tokens');
+
+        $this->expectException(CsrfStorageException::class);
+
+        $this->storage->retrieve('session1');
+    }
+
+    #[Test]
+    public function testWriteFailureThrowsStorageException(): void
+    {
+        $this->pdo->exec('DROP TABLE csrf_tokens');
+
+        $this->expectException(CsrfStorageException::class);
+
+        $this->storage->store('session1', 'token-value', 3600);
+    }
+
+    private function insertRawToken(string $prefixedKey, string $token, int $expiresAt): void
+    {
+        $stmt = $this->pdo->prepare(
+            'INSERT INTO csrf_tokens ("key", "token", "expires_at") VALUES (?, ?, ?)',
+        );
+        $stmt->execute([$prefixedKey, $token, $expiresAt]);
+    }
+
+    private function countRows(): int
+    {
+        $stmt = $this->pdo->prepare('SELECT COUNT(*) FROM csrf_tokens');
+        $stmt->execute();
+
+        return (int) $stmt->fetchColumn();
+    }
+}

--- a/tests/Csrf/Storage/RedisCsrfStorageTest.php
+++ b/tests/Csrf/Storage/RedisCsrfStorageTest.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Zappzarapp\Security\Tests\Csrf\Storage;
+
+use PHPUnit\Framework\Attributes\AllowMockObjectsWithoutExpectations;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Zappzarapp\Security\Csrf\Storage\RedisCsrfStorage;
+
+#[CoversClass(RedisCsrfStorage::class)]
+final class RedisCsrfStorageTest extends TestCase
+{
+    #[Test]
+    public function testStoreWithTtlUsesSetex(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('setex')
+            ->with('csrf:session1', 3600, 'token-value');
+        $redis->expects($this->never())->method('set');
+
+        $storage = new RedisCsrfStorage($redis);
+        $storage->store('session1', 'token-value', 3600);
+    }
+
+    #[Test]
+    public function testStoreWithoutTtlUsesSet(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('set')
+            ->with('csrf:session1', 'token-value');
+        $redis->expects($this->never())->method('setex');
+
+        $storage = new RedisCsrfStorage($redis);
+        $storage->store('session1', 'token-value');
+    }
+
+    #[Test]
+    public function testStoreWithZeroTtlUsesSetWithoutExpiry(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('set')
+            ->with('csrf:session1', 'token-value');
+        $redis->expects($this->never())->method('setex');
+
+        $storage = new RedisCsrfStorage($redis);
+        $storage->store('session1', 'token-value', 0);
+    }
+
+    #[Test]
+    public function testStoreUsesCustomPrefix(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('setex')
+            ->with('app:session1', 3600, 'token-value');
+
+        $storage = new RedisCsrfStorage($redis, 'app:');
+        $storage->store('session1', 'token-value', 3600);
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function testRetrieveReturnsNullWhenMissingFalse(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->method('get')->willReturn(false);
+
+        $storage = new RedisCsrfStorage($redis);
+
+        $this->assertNull($storage->retrieve('session1'));
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function testRetrieveReturnsNullWhenMissingNull(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->method('get')->willReturn(null);
+
+        $storage = new RedisCsrfStorage($redis);
+
+        $this->assertNull($storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testRetrieveReturnsToken(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('get')
+            ->with('csrf:session1')
+            ->willReturn('token-value');
+
+        $storage = new RedisCsrfStorage($redis);
+
+        $this->assertSame('token-value', $storage->retrieve('session1'));
+    }
+
+    #[Test]
+    public function testRemoveDeletesPrefixedKey(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('del')
+            ->with('csrf:session1');
+
+        $storage = new RedisCsrfStorage($redis);
+        $storage->remove('session1');
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function testHasReturnsTrueWhenTokenExists(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->method('get')->willReturn('token-value');
+
+        $storage = new RedisCsrfStorage($redis);
+
+        $this->assertTrue($storage->has('session1'));
+    }
+
+    #[AllowMockObjectsWithoutExpectations]
+    #[Test]
+    public function testHasReturnsFalseWhenTokenMissing(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->method('get')->willReturn(false);
+
+        $storage = new RedisCsrfStorage($redis);
+
+        $this->assertFalse($storage->has('session1'));
+    }
+
+    #[Test]
+    public function testClearDeletesAllMatchingKeys(): void
+    {
+        $keys  = ['csrf:session1', 'csrf:session2'];
+        $redis = $this->createMockRedis();
+        $redis->expects($this->once())
+            ->method('keys')
+            ->with('csrf:*')
+            ->willReturn($keys);
+        $redis->expects($this->once())
+            ->method('del')
+            ->with($keys);
+
+        $storage = new RedisCsrfStorage($redis);
+        $storage->clear();
+    }
+
+    #[Test]
+    public function testClearDoesNothingWhenNoKeysMatch(): void
+    {
+        $redis = $this->createMockRedis();
+        $redis->method('keys')->willReturn([]);
+        $redis->expects($this->never())->method('del');
+
+        $storage = new RedisCsrfStorage($redis);
+        $storage->clear();
+    }
+
+    /**
+     * @return MockObject
+     */
+    private function createMockRedis(): MockObject
+    {
+        return $this->createMock(RedisCsrfMockInterface::class);
+    }
+}
+
+/**
+ * Interface for Redis client mock
+ *
+ * @internal Test interface only
+ *
+ * @psalm-suppress PossiblyUnusedMethod
+ */
+interface RedisCsrfMockInterface
+{
+    public function get(string $key): string|false|null;
+
+    public function set(string $key, string $value): bool;
+
+    public function setex(string $key, int $ttl, string $value): bool;
+
+    /**
+     * @param string|list<string> $key
+     */
+    public function del(string|array $key): int;
+
+    /**
+     * @return list<string>
+     */
+    public function keys(string $pattern): array;
+}


### PR DESCRIPTION
## Summary

Adds `RedisCsrfStorage` and `PdoCsrfStorage` implementing `CsrfStorageInterface`, enabling distributed/stateless CSRF protection beyond the existing Session and Array backends.

- **`RedisCsrfStorage`** — supports phpredis and Predis (duck-typed client, consistent with `RateLimiting\Storage\RedisStorage`). A non-null TTL maps to a Redis key expiry; a null TTL stores without expiry. `clear()` enumerates keys via `KEYS` (documented as a maintenance operation).
- **`PdoCsrfStorage`** — MySQL, PostgreSQL, SQLite with a bundled `SCHEMA`, nullable expiry, and a `cleanup()` helper for purging expired tokens.
- Both namespace keys with a configurable prefix; storage errors surface as the new `CsrfStorageException`.

## Changes

- `src/Csrf/Storage/RedisCsrfStorage.php`, `src/Csrf/Storage/PdoCsrfStorage.php` — new backends
- `src/Csrf/Exception/CsrfStorageException.php` — storage exception
- `deptrac.yaml` — `CsrfStorage` may depend on `CsrfException`
- `composer.json` — broadened redis/predis/pdo `suggest` to mention CSRF
- `infection.json5` — equivalent-mutant ignores for `PdoCsrfStorage` (MySQL arm untestable without MySQL; defensive PDO cast), mirroring `PdoStorage`
- `docs/csrf.md` — Redis/PDO storage sections
- Tests — Redis 12, PDO 17 (in-memory SQLite)

## Quality Gates

- PHPStan L8, Psalm L1, PHPMD, Deptrac (0 violations), CS-Fixer, Rector: pass
- PHPUnit: Redis on php84; PDO via SQLite
- Infection runs in CI; equivalent mutants pre-empted (is_string narrowing, negative-TTL test, mirrored PDO ignores)
- Security review: no findings

## Follow-up

The Redis duck typing is tracked for a typed interface in #67 (milestone 2.0.0), consistent with the existing `RateLimiting` Redis backends.

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)