### PR TITLE
test(middleware): use createStub() for expectation-less mocks

### DIFF
--- a/tests/Middleware/CspMiddlewareTest.php
+++ b/tests/Middleware/CspMiddlewareTest.php
@@ -33,7 +33,7 @@ final class CspMiddlewareTest extends TestCase
 
         $appliedHeaders = [];
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('withHeader')
             ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
                 $appliedHeaders[$name] = $value;
@@ -41,7 +41,7 @@ final class CspMiddlewareTest extends TestCase
                 return $response;
             });
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createStub(ServerRequestInterface::class);
         $request->method('withAttribute')->willReturn($request);
 
         $handler = $this->createStub(RequestHandlerInterface::class);
@@ -61,7 +61,7 @@ final class CspMiddlewareTest extends TestCase
 
         $appliedHeaders = [];
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('withHeader')
             ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
                 $appliedHeaders[$name] = $value;
@@ -69,7 +69,7 @@ final class CspMiddlewareTest extends TestCase
                 return $response;
             });
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createStub(ServerRequestInterface::class);
         $request->method('withAttribute')->willReturn($request);
 
         $handler = $this->createStub(RequestHandlerInterface::class);
@@ -111,7 +111,7 @@ final class CspMiddlewareTest extends TestCase
 
         $storedProvider = null;
 
-        $request = $this->createMock(ServerRequestInterface::class);
+        $request = $this->createStub(ServerRequestInterface::class);
         $request->method('withAttribute')
             ->willReturnCallback(function (string $name, mixed $value) use (&$storedProvider, $request): ServerRequestInterface {
                 if ($name === CspMiddleware::NONCE_ATTRIBUTE) {

--- a/tests/Middleware/CsrfMiddlewareTest.php
+++ b/tests/Middleware/CsrfMiddlewareTest.php
@@ -9,7 +9,7 @@ namespace Zappzarapp\Security\Tests\Middleware;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\Attributes\UsesClass;
-use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\MockObject\Stub;
 use PHPUnit\Framework\TestCase;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
@@ -213,8 +213,8 @@ final class CsrfMiddlewareTest extends TestCase
         string $method,
         ?string $headerToken = null,
         ?string $bodyToken = null,
-    ): ServerRequestInterface&MockObject {
-        $request = $this->createMock(ServerRequestInterface::class);
+    ): ServerRequestInterface&Stub {
+        $request = $this->createStub(ServerRequestInterface::class);
         $request->method('getMethod')->willReturn($method);
         $request->method('withAttribute')->willReturn($request);
         $request->method('getHeaderLine')

--- a/tests/Middleware/RateLimitMiddlewareTest.php
+++ b/tests/Middleware/RateLimitMiddlewareTest.php
@@ -52,12 +52,12 @@ final class RateLimitMiddlewareTest extends TestCase
     {
         $result = RateLimitResult::denied(10, time() + 60, 60);
 
-        $limiter = $this->createMock(RateLimiter::class);
+        $limiter = $this->createStub(RateLimiter::class);
         $limiter->method('consume')->willReturn($result);
 
         $appliedHeaders = [];
 
-        $deniedResponse = $this->createMock(ResponseInterface::class);
+        $deniedResponse = $this->createStub(ResponseInterface::class);
         $deniedResponse->method('withHeader')
             ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $deniedResponse): ResponseInterface {
                 $appliedHeaders[$name] = $value;
@@ -90,7 +90,7 @@ final class RateLimitMiddlewareTest extends TestCase
 
         $appliedHeaders = [];
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('withHeader')
             ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
                 $appliedHeaders[$name] = $value;

--- a/tests/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/Middleware/SecurityHeadersMiddlewareTest.php
@@ -32,7 +32,7 @@ final class SecurityHeadersMiddlewareTest extends TestCase
 
         $appliedHeaders = [];
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('withHeader')
             ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
                 $appliedHeaders[$name] = $value;
@@ -40,7 +40,7 @@ final class SecurityHeadersMiddlewareTest extends TestCase
                 return $response;
             });
 
-        $handler = $this->createMock(RequestHandlerInterface::class);
+        $handler = $this->createStub(RequestHandlerInterface::class);
         $handler->method('handle')->willReturn($response);
 
         $request = $this->createStub(ServerRequestInterface::class);
@@ -78,7 +78,7 @@ final class SecurityHeadersMiddlewareTest extends TestCase
 
         $appliedHeaders = [];
 
-        $response = $this->createMock(ResponseInterface::class);
+        $response = $this->createStub(ResponseInterface::class);
         $response->method('withHeader')
             ->willReturnCallback(function (string $name, string $value) use (&$appliedHeaders, $response): ResponseInterface {
                 $appliedHeaders[$name] = $value;


### PR DESCRIPTION
## Summary

Replaces `createMock()` with `createStub()` for test doubles that only stub return values (no `->expects()`), eliminating the PHPUnit 13 *"No expectations were configured for the mock object"* notices.

Scope: the 4 middleware test files that produced all 18 notices — `CsrfMiddlewareTest` (via its `createRequest()` helper), `CspMiddlewareTest`, `RateLimitMiddlewareTest`, `SecurityHeadersMiddlewareTest`. Mocks that set `->expects()` expectations are left as `createMock()`.

## Result

- PHPUnit notices: **18 → 0** across the suite
- PHPStan L8, Psalm L1, CS-Fixer: pass; 3204 tests green

## Deliberately out of scope

`RedisStorageTest` and `RedisCsrfStorageTest` use `#[AllowMockObjectsWithoutExpectations]` on a **dual-use** custom-interface mock helper (the same mock is used with and without `expects()`). A stub cannot carry `expects()`, so the attribute is the correct tool there and those tests already emit no notice. `MemcachedStorageTest` is already clean.

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)