### PR TITLE
build: reference local PHPUnit XSD for offline schema validation

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/13.1/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
          cacheDirectory="build/.phpunit.cache"


### PR DESCRIPTION
## Problem

PHPUnit 13.1 has no published XSD on `schema.phpunit.de` — the CDN returns a `404` (a 14-byte body) for `https://schema.phpunit.de/13.1/phpunit.xsd`, while older versions (13.0, 12.5, …) are present.

Infection validates the generated PHPUnit configuration against the `xsi:noNamespaceSchemaLocation` declared in `phpunit.xml.dist`. With the 13.1 URL returning a 404, validation aborts:

```
The file "…/phpunitConfiguration.initial.infection.xml" does not pass the XSD schema validation.
[Fatal] Start tag expected, '<' not found in https://schema.phpunit.de/13.1/phpunit.xsd
```

This breaks `make infection` / the mutation-testing CI step for **every** branch as long as PHPUnit 13.1 is installed.

## Fix

Point `xsi:noNamespaceSchemaLocation` at the XSD shipped inside the installed package (`vendor/phpunit/phpunit/phpunit.xsd`). Schema validation now works offline and is no longer tied to a CDN-published version.

## Verification

- `make check` (incl. PHPUnit) passes
- `make infection` no longer fails at config validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)